### PR TITLE
Supports decoding for null value

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,25 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header,diff"
+  behavior: default
+  require_changes: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,8 +7,10 @@ coverage:
   range: "70...100"
 
   status:
-    project: yes
-    patch: yes
+    project:
+      default:
+        target: 80%
+    patch: no
     changes: no
 
 parsers:

--- a/decode_test.go
+++ b/decode_test.go
@@ -279,6 +279,25 @@ func TestDecoder(t *testing.T) {
 			"a: 50cent_of_dollar",
 			map[string]interface{}{"a": "50cent_of_dollar"},
 		},
+
+		// Nulls
+		{
+			"v:",
+			map[string]interface{}{"v": nil},
+		},
+		{
+			"v: ~",
+			map[string]interface{}{"v": nil},
+		},
+		{
+			"~: null key",
+			map[interface{}]string{nil: "null key"},
+		},
+		{
+			"v:",
+			map[string]*bool{"v": nil},
+		},
+
 		{
 			"v: .inf\n",
 			map[string]interface{}{"v": math.Inf(0)},

--- a/decode_test.go
+++ b/decode_test.go
@@ -41,6 +41,18 @@ func TestDecoder(t *testing.T) {
 			map[string]string{"v": "true"},
 		},
 		{
+			"v: 10\n",
+			map[string]string{"v": "10"},
+		},
+		{
+			"v: -10\n",
+			map[string]string{"v": "-10"},
+		},
+		{
+			"v: 1.234\n",
+			map[string]string{"v": "1.234"},
+		},
+		{
 			"v: false\n",
 			map[string]bool{"v": false},
 		},
@@ -544,7 +556,7 @@ func TestDecoder(t *testing.T) {
 	}
 }
 
-func TestDecodeByAnchorOfOtherFile(t *testing.T) {
+func TestDecoder_AnchorReferenceDirs(t *testing.T) {
 	buf := bytes.NewBufferString("a: *a\n")
 	dec := yaml.NewDecoder(buf, yaml.ReferenceDirs("testdata"))
 	var v struct {
@@ -555,6 +567,56 @@ func TestDecodeByAnchorOfOtherFile(t *testing.T) {
 	}
 	if err := dec.Decode(&v); err != nil {
 		t.Fatalf("%+v", err)
+	}
+	if v.A.B != 1 {
+		t.Fatal("failed to decode by reference dirs")
+	}
+	if v.A.C != "hello" {
+		t.Fatal("failed to decode by reference dirs")
+	}
+}
+
+func TestDecoder_AnchorReferenceDirsRecursive(t *testing.T) {
+	buf := bytes.NewBufferString("a: *a\n")
+	dec := yaml.NewDecoder(
+		buf,
+		yaml.RecursiveDir(true),
+		yaml.ReferenceDirs("testdata"),
+	)
+	var v struct {
+		A struct {
+			B int
+			C string
+		}
+	}
+	if err := dec.Decode(&v); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if v.A.B != 1 {
+		t.Fatal("failed to decode by reference dirs")
+	}
+	if v.A.C != "hello" {
+		t.Fatal("failed to decode by reference dirs")
+	}
+}
+
+func TestDecoder_AnchorFiles(t *testing.T) {
+	buf := bytes.NewBufferString("a: *a\n")
+	dec := yaml.NewDecoder(buf, yaml.ReferenceFiles("testdata/anchor.yml"))
+	var v struct {
+		A struct {
+			B int
+			C string
+		}
+	}
+	if err := dec.Decode(&v); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if v.A.B != 1 {
+		t.Fatal("failed to decode by reference dirs")
+	}
+	if v.A.C != "hello" {
+		t.Fatal("failed to decode by reference dirs")
 	}
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -141,13 +141,6 @@ func (p *Parser) parseTag(ctx *Context) (ast.Node, error) {
 	return node, nil
 }
 
-func (p *Parser) isMapNode(node ast.Node) bool {
-	if _, ok := node.(*ast.MappingValueNode); ok {
-		return true
-	}
-	return false
-}
-
 func (p *Parser) validateMapKey(tk *token.Token) error {
 	if tk.Type != token.StringType {
 		return nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -173,9 +173,15 @@ func (p *Parser) parseMappingValue(ctx *Context) (ast.Node, error) {
 	ctx.progress(1)          // progress to mapping value token
 	tk := ctx.currentToken() // get mapping value token
 	ctx.progress(1)          // progress to value token
-	value, err := p.parseToken(ctx, ctx.currentToken())
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse mapping 'value' node")
+	var value ast.Node
+	if vtk := ctx.currentToken(); vtk == nil {
+		value = ast.Null(token.New("null", "null", tk.Position))
+	} else {
+		v, err := p.parseToken(ctx, ctx.currentToken())
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse mapping 'value' node")
+		}
+		value = v
 	}
 	keyColumn := key.GetToken().Position.Column
 	valueColumn := value.GetToken().Position.Column
@@ -298,6 +304,9 @@ func (p *Parser) parseMapKey(tk *token.Token) ast.Node {
 	}
 	if tk.Type == token.MergeKeyType {
 		return ast.MergeKey(tk)
+	}
+	if tk.Type == token.NullType {
+		return ast.Null(tk)
 	}
 	return nil
 }

--- a/scanner/context.go
+++ b/scanner/context.go
@@ -66,6 +66,10 @@ func (c *Context) isEOS() bool {
 	return len(c.src)-1 <= c.idx
 }
 
+func (c *Context) isNextEOS() bool {
+	return len(c.src)-1 <= c.idx+1
+}
+
 func (c *Context) next() bool {
 	return c.idx < c.size
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -364,7 +364,7 @@ func (s *Scanner) scan(ctx *Context) (pos int) {
 			return
 		case ':':
 			nc := ctx.nextChar()
-			if nc == ' ' || nc == '\n' {
+			if nc == ' ' || nc == '\n' || ctx.isNextEOS() {
 				// mapping value
 				tk := s.bufferedToken(ctx)
 				if tk != nil {

--- a/token/token.go
+++ b/token/token.go
@@ -274,6 +274,8 @@ type ReservedKeyword string
 const (
 	// Null `null` keyword
 	Null ReservedKeyword = "null"
+	// NullSymbol `~` keyword
+	NullSymbol = "~"
 	// False `false` keyword
 	False = "false"
 	// True `true` keyword
@@ -290,6 +292,16 @@ var (
 	// ReservedKeywordMap map for reserved keywords
 	ReservedKeywordMap = map[ReservedKeyword]func(string, string, *Position) *Token{
 		Null: func(value string, org string, pos *Position) *Token {
+			return &Token{
+				Type:          NullType,
+				CharacterType: CharacterTypeMiscellaneous,
+				Indicator:     NotIndicator,
+				Value:         value,
+				Origin:        org,
+				Position:      pos,
+			}
+		},
+		NullSymbol: func(value, org string, pos *Position) *Token {
 			return &Token{
 				Type:          NullType,
 				CharacterType: CharacterTypeMiscellaneous,

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -42,6 +42,7 @@ func TestToken(t *testing.T) {
 		token.New("+", "+", pos),
 		token.New("-", "-", pos),
 		token.New("_", "_", pos),
+		token.New("~", "~", pos),
 		token.New("true", "true", pos),
 		token.New("false", "false", pos),
 		token.New(".nan", ".nan", pos),


### PR DESCRIPTION
Supports the following
- `v:` to `map[string]interface{}{}`
- `v: ~` to `map[string]interface{}{}`
- `~: null key` to `map[interface{}]string{}`
- `v:` to `map[string]*bool{}`