### PR TITLE
Fix parser API

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -104,11 +104,13 @@ type Node interface {
 	Type() NodeType
 }
 
+// File contains all documents in YAML file
 type File struct {
 	Name string
 	Docs []*Document
 }
 
+// String all documents to text
 func (f *File) String() string {
 	docs := []string{}
 	for _, doc := range f.Docs {
@@ -124,6 +126,7 @@ type Document struct {
 	Body  Node
 }
 
+// GetToken returns token instance
 func (d *Document) GetToken() *token.Token {
 	return d.Body.GetToken()
 }

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -104,10 +104,28 @@ type Node interface {
 	Type() NodeType
 }
 
+type File struct {
+	Name string
+	Docs []*Document
+}
+
+func (f *File) String() string {
+	docs := []string{}
+	for _, doc := range f.Docs {
+		docs = append(docs, doc.String())
+	}
+	return strings.Join(docs, "\n")
+}
+
 // Document type of Document
 type Document struct {
-	// Nodes all nodes in document
-	Nodes []Node
+	Start *token.Token // position of DocumentHeader ( `---` )
+	End   *token.Token // position of DocumentEnd ( `...` )
+	Body  Node
+}
+
+func (d *Document) GetToken() *token.Token {
+	return d.Body.GetToken()
 }
 
 // Type returns DocumentType
@@ -115,11 +133,15 @@ func (d *Document) Type() NodeType { return DocumentType }
 
 // String document to text
 func (d *Document) String() string {
-	values := []string{}
-	for _, node := range d.Nodes {
-		values = append(values, strings.TrimLeft(node.String(), " "))
+	doc := []string{}
+	if d.Start != nil {
+		doc = append(doc, d.Start.Value)
 	}
-	return strings.Join(values, "\n")
+	doc = append(doc, d.Body.String())
+	if d.End != nil {
+		doc = append(doc, d.End.Value)
+	}
+	return strings.Join(doc, "\n")
 }
 
 // ScalarNode type for scalar node

--- a/decode.go
+++ b/decode.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/internal/errors"
-	"github.com/goccy/go-yaml/lexer"
 	"github.com/goccy/go-yaml/parser"
 	"github.com/goccy/go-yaml/token"
 	"golang.org/x/xerrors"
@@ -205,10 +204,10 @@ func (d *Decoder) getArrayNode(node ast.Node) (ast.ArrayNode, error) {
 	return arrayNode, nil
 }
 
-func (d *Decoder) docToNode(doc *ast.Document) ast.Node {
-	for _, node := range doc.Nodes {
-		if v := d.nodeToValue(node); v != nil {
-			return node
+func (d *Decoder) fileToNode(f *ast.File) ast.Node {
+	for _, doc := range f.Docs {
+		if v := d.nodeToValue(doc.Body); v != nil {
+			return doc.Body
 		}
 	}
 	return nil
@@ -768,15 +767,11 @@ func (d *Decoder) resolveReference() error {
 }
 
 func (d *Decoder) decode(bytes []byte) (ast.Node, error) {
-	var (
-		parser parser.Parser
-	)
-	tokens := lexer.Tokenize(string(bytes))
-	doc, err := parser.Parse(tokens)
+	f, err := parser.ParseBytes(bytes, 0)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse yaml")
 	}
-	return d.docToNode(doc), nil
+	return d.fileToNode(f), nil
 }
 
 // Decode reads the next YAML-encoded value from its input

--- a/encode.go
+++ b/encode.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/internal/errors"
-	"github.com/goccy/go-yaml/lexer"
 	"github.com/goccy/go-yaml/parser"
 	"github.com/goccy/go-yaml/printer"
 	"github.com/goccy/go-yaml/token"
@@ -80,17 +79,13 @@ func (e *Encoder) Encode(v interface{}) error {
 }
 
 func (e *Encoder) encodeDocument(doc []byte) (ast.Node, error) {
-	var (
-		parser parser.Parser
-	)
-	tokens := lexer.Tokenize(string(doc))
-	docNode, err := parser.Parse(tokens)
+	f, err := parser.ParseBytes(doc, 0)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse yaml")
 	}
-	for _, node := range docNode.Nodes {
-		if node != nil {
-			return node, nil
+	for _, docNode := range f.Docs {
+		if docNode.Body != nil {
+			return docNode.Body, nil
 		}
 	}
 	return nil, nil

--- a/parser/context.go
+++ b/parser/context.go
@@ -1,0 +1,75 @@
+package parser
+
+import "github.com/goccy/go-yaml/token"
+
+// context context at parsing
+type context struct {
+	idx    int
+	size   int
+	tokens token.Tokens
+	mode   Mode
+}
+
+func (c *context) next() bool {
+	return c.idx < c.size
+}
+
+func (c *context) previousToken() *token.Token {
+	if c.idx > 0 {
+		return c.tokens[c.idx-1]
+	}
+	return nil
+}
+
+func (c *context) currentToken() *token.Token {
+	if c.idx >= c.size {
+		return nil
+	}
+	return c.tokens[c.idx]
+}
+
+func (c *context) nextToken() *token.Token {
+	if c.size > c.idx+1 {
+		return c.tokens[c.idx+1]
+	}
+	return nil
+}
+
+func (c *context) afterNextToken() *token.Token {
+	if c.size > c.idx+2 {
+		return c.tokens[c.idx+2]
+	}
+	return nil
+}
+
+func (c *context) enabledComment() bool {
+	return c.mode&ParseComments != 0
+}
+
+func (c *context) progress(num int) {
+	if c.size <= c.idx+num {
+		c.idx = c.size
+	} else {
+		c.idx += num
+	}
+}
+
+func newContext(tokens token.Tokens, mode Mode) *context {
+	filteredTokens := token.Tokens{}
+	if mode&ParseComments != 0 {
+		filteredTokens = tokens
+	} else {
+		for _, tk := range tokens {
+			if tk.Type == token.CommentType {
+				continue
+			}
+			filteredTokens.Add(tk)
+		}
+	}
+	return &context{
+		idx:    0,
+		size:   len(filteredTokens),
+		tokens: filteredTokens,
+		mode:   mode,
+	}
+}


### PR DESCRIPTION
### BEFORE

```
var p parser.Parser
doc, err := p.Parse(tokens)
```

### AFTER

```
file, err := parser.Parse(tokens, parser.Mode(0))
// file contains multiple documents
```
