### PR TITLE
Comments must be separated from other tokens by white space characters

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -263,6 +263,14 @@ d: e
 		},
 		{
 			`
+a: b#notcomment
+`,
+			`
+a: b#notcomment
+`,
+		},
+		{
+			`
 anchored: &anchor foo
 aliased: *anchor
 `,

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -476,13 +476,15 @@ func (s *Scanner) scan(ctx *Context) (pos int) {
 				return
 			}
 		case '#':
-			s.addBufferedTokenIfExists(ctx)
-			token, progress := s.scanComment(ctx)
-			ctx.addToken(token)
-			s.progressColumn(ctx, progress)
-			s.progressLine(ctx)
-			pos += progress
-			return
+			if ctx.bufferedSrc() == "" || ctx.previousChar() == ' ' {
+				s.addBufferedTokenIfExists(ctx)
+				token, progress := s.scanComment(ctx)
+				ctx.addToken(token)
+				s.progressColumn(ctx, progress)
+				s.progressLine(ctx)
+				pos += progress
+				return
+			}
 		case '\'', '"':
 			if ctx.bufferedSrc() == "" {
 				token, progress := s.scanQuote(ctx, c)


### PR DESCRIPTION
ref: https://yaml.org/spec/1.2/spec.html#id2780069

仕様の方もコードの方も読み込みきれてないので、実装があってるかどうか少し不安なのですが、コメントは `#`の前にスペースが必要だと思います