### PR TITLE
Fix disallow unknown field error

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -270,11 +270,15 @@ func errTypeMismatch(dstType, srcType reflect.Type) *typeError {
 }
 
 type unknownFieldError struct {
-	*errors.SyntaxError
+	err error
 }
 
-func errUnknowField(msg string, tk *token.Token) *unknownFieldError {
-	return &unknownFieldError{SyntaxError: errors.ErrSyntax(msg, tk)}
+func (e *unknownFieldError) Error() string {
+	return e.err.Error()
+}
+
+func errUnknownField(msg string, tk *token.Token) *unknownFieldError {
+	return &unknownFieldError{err: errors.ErrSyntax(msg, tk)}
 }
 
 func (d *Decoder) deleteStructKeys(str reflect.Value, unknownFields map[string]ast.Node) error {
@@ -677,7 +681,7 @@ func (d *Decoder) decodeStruct(dst reflect.Value, src ast.Node) error {
 	dst.Set(structValue.Elem())
 	if len(unknownFields) != 0 && d.disallowUnknownField {
 		for key, node := range unknownFields {
-			return errUnknowField(fmt.Sprintf(`unknown field "%s"`, key), node.GetToken())
+			return errUnknownField(fmt.Sprintf(`unknown field "%s"`, key), node.GetToken())
 		}
 	}
 	if foundErr != nil {

--- a/decode.go
+++ b/decode.go
@@ -627,8 +627,7 @@ func (d *Decoder) decodeStruct(dst reflect.Value, src ast.Node) error {
 						continue
 					}
 
-					err = d.deleteStructKeys(fieldValue, unknownFields)
-					if err != nil {
+					if err = d.deleteStructKeys(fieldValue, unknownFields); err != nil {
 						return errors.Wrapf(err, "cannot delete struct keys")
 					}
 				} else {

--- a/decode.go
+++ b/decode.go
@@ -619,7 +619,7 @@ func (d *Decoder) decodeStruct(dst reflect.Value, src ast.Node) error {
 
 				err = d.deleteStructKeys(fieldValue, unknownFields)
 				if err != nil {
-					return err
+					return errors.Wrapf(err, "cannot delete struct keys")
 				}
 			}
 			d.setDefaultValueIfConflicted(newFieldValue, structFieldMap)

--- a/decode_test.go
+++ b/decode_test.go
@@ -1194,6 +1194,47 @@ b_yaml: b_yaml_value
 	}
 }
 
+func TestDecoder_DisallowUnknownField(t *testing.T) {
+	t.Run("duplicate key but different level", func(t *testing.T) {
+		var v struct {
+			C Child `yaml:"c"`
+		}
+		yml := `---
+b: 1
+c:
+  b: 1
+`
+
+		err := yaml.NewDecoder(strings.NewReader(yml), yaml.DisallowUnknownField()).Decode(&v)
+		if err == nil {
+			t.Fatalf("error expected")
+		}
+	})
+	t.Run("inline", func(t *testing.T) {
+		var v struct {
+			Child `yaml:",inline"`
+			A     string `yaml:"a"`
+		}
+		yml := `---
+a: a
+b: 1
+`
+
+		if err := yaml.NewDecoder(strings.NewReader(yml), yaml.DisallowUnknownField()).Decode(&v); err != nil {
+			t.Fatalf(`parsing should succeed: %s`, err)
+		}
+		if v.A != "a" {
+			t.Fatalf("v.A should be `a`, got `%s`", v.A)
+		}
+		if v.B != 1 {
+			t.Fatalf("v.B should be 1, got %d", v.B)
+		}
+		if v.C != 0 {
+			t.Fatalf("v.C should be 0, got %d", v.C)
+		}
+	})
+}
+
 func Example_YAMLTags() {
 	yml := `---
 foo: 1

--- a/decode_test.go
+++ b/decode_test.go
@@ -1195,7 +1195,7 @@ b_yaml: b_yaml_value
 }
 
 func TestDecoder_DisallowUnknownField(t *testing.T) {
-	t.Run("duplicate key but different level", func(t *testing.T) {
+	t.Run("different level keys with same name", func(t *testing.T) {
 		var v struct {
 			C Child `yaml:"c"`
 		}

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -29,8 +29,8 @@ func Wrapf(err error, msg string, args ...interface{}) error {
 }
 
 // ErrSyntax create syntax error instance with message and token
-func ErrSyntax(msg string, tk *token.Token) *SyntaxError {
-	return &SyntaxError{
+func ErrSyntax(msg string, tk *token.Token) *syntaxError {
+	return &syntaxError{
 		baseError: &baseError{},
 		msg:       msg,
 		token:     tk,
@@ -53,7 +53,7 @@ func (e *baseError) chainStateAndVerb(err error) {
 		wrapErr.state = e.state
 		wrapErr.verb = e.verb
 	}
-	syntaxErr, ok := err.(*SyntaxError)
+	syntaxErr, ok := err.(*syntaxError)
 	if ok {
 		syntaxErr.state = e.state
 		syntaxErr.verb = e.verb
@@ -159,18 +159,18 @@ func (e *wrapError) Error() string {
 	return buf.String()
 }
 
-type SyntaxError struct {
+type syntaxError struct {
 	*baseError
 	msg   string
 	token *token.Token
 	frame xerrors.Frame
 }
 
-func (e *SyntaxError) PrettyPrint(p xerrors.Printer, colored, inclSource bool) error {
+func (e *syntaxError) PrettyPrint(p xerrors.Printer, colored, inclSource bool) error {
 	return e.FormatError(&myprinter{Printer: p, colored: colored, inclSource: inclSource})
 }
 
-func (e *SyntaxError) FormatError(p xerrors.Printer) error {
+func (e *syntaxError) FormatError(p xerrors.Printer) error {
 	var pp printer.Printer
 
 	var colored, inclSource bool
@@ -211,7 +211,7 @@ func (es *Sink) Detail() bool {
 	return false
 }
 
-func (e *SyntaxError) Error() string {
+func (e *syntaxError) Error() string {
 	var buf bytes.Buffer
 	e.PrettyPrint(&Sink{&buf}, defaultColorize, defaultIncludeSource)
 	return buf.String()

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -29,8 +29,8 @@ func Wrapf(err error, msg string, args ...interface{}) error {
 }
 
 // ErrSyntax create syntax error instance with message and token
-func ErrSyntax(msg string, tk *token.Token) *syntaxError {
-	return &syntaxError{
+func ErrSyntax(msg string, tk *token.Token) *SyntaxError {
+	return &SyntaxError{
 		baseError: &baseError{},
 		msg:       msg,
 		token:     tk,
@@ -53,7 +53,7 @@ func (e *baseError) chainStateAndVerb(err error) {
 		wrapErr.state = e.state
 		wrapErr.verb = e.verb
 	}
-	syntaxErr, ok := err.(*syntaxError)
+	syntaxErr, ok := err.(*SyntaxError)
 	if ok {
 		syntaxErr.state = e.state
 		syntaxErr.verb = e.verb
@@ -159,18 +159,18 @@ func (e *wrapError) Error() string {
 	return buf.String()
 }
 
-type syntaxError struct {
+type SyntaxError struct {
 	*baseError
 	msg   string
 	token *token.Token
 	frame xerrors.Frame
 }
 
-func (e *syntaxError) PrettyPrint(p xerrors.Printer, colored, inclSource bool) error {
+func (e *SyntaxError) PrettyPrint(p xerrors.Printer, colored, inclSource bool) error {
 	return e.FormatError(&myprinter{Printer: p, colored: colored, inclSource: inclSource})
 }
 
-func (e *syntaxError) FormatError(p xerrors.Printer) error {
+func (e *SyntaxError) FormatError(p xerrors.Printer) error {
 	var pp printer.Printer
 
 	var colored, inclSource bool
@@ -211,7 +211,7 @@ func (es *Sink) Detail() bool {
 	return false
 }
 
-func (e *syntaxError) Error() string {
+func (e *SyntaxError) Error() string {
 	var buf bytes.Buffer
 	e.PrettyPrint(&Sink{&buf}, defaultColorize, defaultIncludeSource)
 	return buf.String()


### PR DESCRIPTION
Related #56 
I noticed error when use inline field. I'm sorry...

Ex)

```go
type Child struct {
	B int
}

var v struct {
	Child `yaml:",inline"`
	A     string
}
yml := `---
a: string
b: 0
`

d := yaml.NewDecoder(strings.NewReader(yml), yaml.DisallowUnknownField())
err := d.Decode(&v)
fmt.Println(err)
// OUT:
// [3:1] unknown field "b"
//        1 | ---
//        2 | a: string
//     >  3 | b: 0
//           ^

```