### PR TITLE
Encode both empty and nil slices into `[]`

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -231,7 +231,11 @@ func (e *Encoder) encodeBool(v bool) ast.Node {
 }
 
 func (e *Encoder) encodeSlice(value reflect.Value) (ast.Node, error) {
-	sequence := ast.Sequence(token.New("-", "-", e.pos(e.column)), e.isFlowStyle)
+	isFlowStyle := e.isFlowStyle
+	if value.Len() == 0 {
+		isFlowStyle = true
+	}
+	sequence := ast.Sequence(token.New("-", "-", e.pos(e.column)), isFlowStyle)
 	for i := 0; i < value.Len(); i++ {
 		node, err := e.encodeValue(value.Index(i), e.column)
 		if err != nil {

--- a/encode_test.go
+++ b/encode_test.go
@@ -189,7 +189,24 @@ func TestEncoder(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			"a: 1\nb: []\n",
+			struct {
+				A int
+				B []string
+			}{
+				1, ([]string)(nil),
+			},
+		},
+		{
+			"a: 1\nb: []\n",
+			struct {
+				A int
+				B []string
+			}{
+				1, []string{},
+			},
+		},
 		{
 			"a: b\nc: d\n",
 			struct {
@@ -264,6 +281,15 @@ func TestEncoder(t *testing.T) {
 				A float64 `yaml:"a,omitempty"`
 				B float64 `yaml:"b,omitempty"`
 			}{1, 0},
+		},
+		{
+			"a: 1\n",
+			struct {
+				A int
+				B []string `yaml:"b,omitempty"`
+			}{
+				1, []string{},
+			},
 		},
 
 		// Flow flag


### PR DESCRIPTION
link: #80 

Encode both empty and nil slices into `[]`

```golang
package main

import (
	"fmt"
	"github.com/goccy/go-yaml"
)

func main() {
	tests := []struct {
		value interface{}
	}{
		{
			value: struct {
				A []string `yaml:"a"`
			}{
				A: []string(nil),
			},
		},
		{
			value: struct {
				A []string `yaml:"a"`
			}{
				A: []string{},
			},
		},
	}
	
	for _, tt := range tests {
		d, _ := yaml.Marshal(tt.value)
		fmt.Printf("%s", string(d))
	}
}
```

**before:**

```
a:
a:
```

**after:**

```
a: []
a: []
```