### PR TITLE
fix dash parsing in a key mapping

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -828,6 +828,16 @@ func TestDecoder(t *testing.T) {
 			"v: あいうえお\nv2: かきくけこ",
 			map[string]string{"v": "あいうえお", "v2": "かきくけこ"},
 		},
+
+		// key with spaces and dash
+		{
+			"a: {b with - dash: c}",
+			map[string]interface{}{
+				"a": map[string]string{
+					"b with - dash": "c",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		buf := bytes.NewBufferString(test.source)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -421,7 +421,7 @@ func (s *Scanner) scan(ctx *Context) (pos int) {
 				s.progressColumn(ctx, 1)
 				continue
 			}
-			if ctx.existsBuffer() && ctx.isSingleLine {
+			if ctx.existsBuffer() && (ctx.isSingleLine || strings.TrimSpace(string(ctx.buf)) != "") {
 				// '-' is literal
 				ctx.addBuf(c)
 				ctx.addOriginBuf(c)


### PR DESCRIPTION
When you have this kind of yaml:
```yml
foo:
  my-key-with-a-dash - with-space: value
```

Token scanner see it as a new sequence entry type the part `- with-space` instead of a string type which should be concatenate to previous data (`my-key-with-a-dash `).

this is caused by lines:  https://github.com/goccy/go-yaml/blob/master/scanner/scanner.go#L431-L440 

This PR simply look at if there is data (which are not spaces) before doing this and if so simply add rune to the current context.