### PR TITLE
Fix decoding for literal with BytesUnmarshaler

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -472,7 +472,7 @@ func (n *LiteralNode) AddColumn(col int) {
 
 // GetValue returns string value
 func (n *LiteralNode) GetValue() interface{} {
-	return n.Value.GetValue()
+	return n.String()
 }
 
 // String literal to text

--- a/decode_test.go
+++ b/decode_test.go
@@ -1585,3 +1585,35 @@ func TestUnmarshalablePtrInt(t *testing.T) {
 		}
 	})
 }
+
+type literalContainer struct {
+	v string
+}
+
+func (c *literalContainer) UnmarshalYAML(v []byte) error {
+	var lit string
+	if err := yaml.Unmarshal(v, &lit); err != nil {
+		return err
+	}
+	c.v = lit
+	return nil
+}
+
+func TestDecode_Literal(t *testing.T) {
+	yml := `---
+value: |
+  {
+     "key": "value"
+  }
+`
+	var v map[string]*literalContainer
+	if err := yaml.Unmarshal([]byte(yml), &v); err != nil {
+		t.Fatalf("failed to unmarshal %+v", err)
+	}
+	if v["value"] == nil {
+		t.Fatal("failed to unmarshal literal with bytes unmarshaler")
+	}
+	if v["value"].v == "" {
+		t.Fatal("failed to unmarshal literal with bytes unmarshaler")
+	}
+}


### PR DESCRIPTION
resolve #89

Add `|` header to string for decoding literal