### PR TITLE
Fix empty map encoding style

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -299,7 +299,11 @@ func (e *Encoder) encodeMapSlice(value MapSlice, column int) (ast.Node, error) {
 }
 
 func (e *Encoder) encodeMap(value reflect.Value, column int) ast.Node {
-	node := ast.Mapping(token.New("", "", e.pos(column)), e.isFlowStyle)
+	isFlowStyle := e.isFlowStyle
+	if value.Len() == 0 {
+		isFlowStyle = true
+	}
+	node := ast.Mapping(token.New("", "", e.pos(column)), isFlowStyle)
 	keys := []string{}
 	for _, k := range value.MapKeys() {
 		keys = append(keys, k.Interface().(string))

--- a/encode_test.go
+++ b/encode_test.go
@@ -235,6 +235,14 @@ func TestEncoder(t *testing.T) {
 			},
 		},
 		{
+			"a: {}\n",
+			struct {
+				A map[string]interface{}
+			}{
+				map[string]interface{}{},
+			},
+		},
+		{
 			"a: b\nc: d\n",
 			struct {
 				A string


### PR DESCRIPTION
Hi @goccy !!  

I want to encode "empty map" like "[empty slice](https://github.com/goccy/go-yaml/pull/81)" ( like go-yaml/yaml ).

| | go-yaml/yaml | encoding/json | goccy/go-yaml v1.4.0 | 
| --- | --- | --- | --- |
| empty map | `a: {}` | `{"a": {}}` | `a: \n{}` |
| play.golang.org | [here](https://play.golang.org/p/K3AyEvSBa4l) | [here](https://play.golang.org/p/3HzSIobVtDl) | [here](https://play.golang.org/p/t-EX0RvQ-Vk) |

```go
package main

import (
	"fmt"

	"github.com/goccy/go-yaml"
)

func main() {
	tests := []struct {
		value interface{}
	}{
		{
			value: struct {
				A map[string]string `yaml:"a"`
			}{
				A: map[string]string{"b":"c"},
			},
		},
		{
			value: struct {
				A map[string]string `yaml:"a"`
			}{
				A: map[string]string{},
			},
		},
	}
	
	for _, tt := range tests {
		d, _ := yaml.Marshal(tt.value)
		fmt.Printf("%s\n", string(d))
	}
}
```

### before

```
a:
  b: c

a:
{}
```

### after

```
a:
  b: c

a: {}
```

Thank you for your GREAT Go-libs !! ( go-yaml 👍 go-graphviz 👍 )