### PR TITLE
Support "c-directives-end marker only" document.

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -688,6 +688,10 @@ func TestDecoder(t *testing.T) {
 			(*struct{})(nil),
 		},
 		{
+			"---\n",
+			(*struct{})(nil),
+		},
+		{
 			"a: !!binary gIGC\n",
 			map[string]string{"a": "\x80\x81\x82"},
 		},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -335,6 +335,9 @@ func (p *parser) parseDocument(ctx *context) (*ast.Document, error) {
 }
 
 func (p *parser) parseToken(ctx *context, tk *token.Token) (ast.Node, error) {
+	if tk == nil {
+		return nil, nil
+	}
 	if tk.NextType() == token.MappingValueType {
 		return p.parseMappingValue(ctx)
 	}


### PR DESCRIPTION
Hi @goccy !

I did a minor fix. 

| | go-yaml/yaml | goccy/go-yaml v1.4.1 | 
| --- | --- | --- | 
| `---\n` | can decode | panic | 
| play.golang.org | [here](https://play.golang.org/p/lM7J0n6wpoP) | [here](https://play.golang.org/p/-cQ7iqGMnB) |

### `---\n` is valid YAML ?

I referred to "9.1.4. Explicit Documents" in https://yaml.org/spec/1.2/spec.pdf

Thank you !!