### PR TITLE
Fix empty struct ( all fields have `yaml:"omitempty"` ) encoding style

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -406,6 +406,7 @@ func (e *Encoder) encodeStruct(value reflect.Value, column int) (ast.Node, error
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get struct field map")
 	}
+	emptyFields := true
 	hasInlineAnchorField := false
 	var inlineAnchorValue reflect.Value
 	for i := 0; i < value.NumField(); i++ {
@@ -419,6 +420,7 @@ func (e *Encoder) encodeStruct(value reflect.Value, column int) (ast.Node, error
 			// omit encoding
 			continue
 		}
+		emptyFields = false
 		value, err := e.encodeValue(fieldValue, column)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to encode value")
@@ -513,6 +515,9 @@ func (e *Encoder) encodeStruct(value reflect.Value, column int) (ast.Node, error
 			Key:   key,
 			Value: value,
 		})
+	}
+	if emptyFields {
+		node.IsFlowStyle = true
 	}
 	if hasInlineAnchorField {
 		node.AddColumn(e.indent)

--- a/encode_test.go
+++ b/encode_test.go
@@ -318,6 +318,32 @@ func TestEncoder(t *testing.T) {
 		},
 
 		{
+			"a:\n  y: \"\"\n",
+			struct {
+				A *struct {
+					X string `yaml:"x,omitempty"`
+					Y string
+				}
+			}{&struct {
+				X string `yaml:"x,omitempty"`
+				Y string
+			}{}},
+		},
+
+		{
+			"a: {}\n",
+			struct {
+				A *struct {
+					X string `yaml:"x,omitempty"`
+					Y string `yaml:"y,omitempty"`
+				}
+			}{&struct {
+				X string `yaml:"x,omitempty"`
+				Y string `yaml:"y,omitempty"`
+			}{}},
+		},
+
+		{
 			"a: {x: 1}\n",
 			struct {
 				A *struct{ X, y int } `yaml:"a,omitempty,flow"`


### PR DESCRIPTION
Hi @goccy !!  

I want to encode  empty struct ( all fields have `yaml:"omitempty"` ) like go-yaml/yaml. 

| | go-yaml/yaml | encoding/json | goccy/go-yaml v1.4.2 | 
| --- | --- | --- | --- |
| empty map | `a: {}` | `{"A":{}}` | `a: \n{}` |
| play.golang.org | [here](https://play.golang.org/p/G9yj9yLEJEc) | [here](https://play.golang.org/p/qt-fxilgGIi) | [here](https://play.golang.org/p/qcTd1c30Hiy) |

```go
package main

import (
	"fmt"

	"github.com/goccy/go-yaml"
)

type A struct {
	B string `yaml:"b,omitempty"`
	C string `yaml:"c,omitempty"`
}

func main() {
	tests := []struct {
		value interface{}
	}{
		{
			value: struct {
				A *A
			}{
				A: &A{},
			},
		},
	}

	for _, tt := range tests {
		d, _ := yaml.Marshal(tt.value)
		fmt.Printf("%s\n", string(d))
	}
}
```

### before

```
a:
{}
```

### after

```
a: {}
```

Thank you !!!