### PR TITLE
return io.EOF if Decoder did not find node

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1070,7 +1070,7 @@ func (d *Decoder) Decode(v interface{}) error {
 		return errors.Wrapf(err, "failed to decode")
 	}
 	if node == nil {
-		return nil
+		return io.EOF
 	}
 	if err := d.decodeValue(rv.Elem(), node); err != nil {
 		return errors.Wrapf(err, "failed to decode value")


### PR DESCRIPTION
This allows this package as a drop-in replacement for `gopkg.in/yaml.v2`.

Besides, It would otherwise be impossible to know if any node were found, since users can have intended `zero values`.