### PR TITLE
add (*wrapError).Unwrap() to be usable for (x)errors.Is

### DIFF
--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -85,6 +85,10 @@ func (e *wrapError) As(target interface{}) bool {
 	return xerrors.As(err, target)
 }
 
+func (e *wrapError) Unwrap() error {
+	return e.nextErr
+}
+
 func (e *wrapError) PrettyPrint(p xerrors.Printer, colored, inclSource bool) error {
 	return e.FormatError(&myprinter{Printer: p, colored: colored, inclSource: inclSource})
 }


### PR DESCRIPTION
currently we cannot `errors.Unwrap()` or `errors.Is()` for the errors returned from `UnmarshalYAML()` so I defined `(*wrapError).Unwrap()` method.