### PR TITLE
Add UseOrderedMap option

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1703,3 +1703,28 @@ value: |
 		t.Fatal("failed to unmarshal literal with bytes unmarshaler")
 	}
 }
+
+func TestDecoder_UseOrderedMap(t *testing.T) {
+	yml := `
+a: b
+c: d
+e:
+  f: g
+  h: i
+j: k
+`
+	var v interface{}
+	if err := yaml.NewDecoder(strings.NewReader(yml), yaml.UseOrderedMap()).Decode(&v); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if _, ok := v.(yaml.MapSlice); !ok {
+		t.Fatalf("failed to convert to ordered map: %T", v)
+	}
+	bytes, err := yaml.Marshal(v)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if string(yml) != "\n"+string(bytes) {
+		t.Fatalf("expected:[%s] actual:[%s]", string(yml), "\n"+string(bytes))
+	}
+}

--- a/option.go
+++ b/option.go
@@ -59,6 +59,15 @@ func DisallowUnknownField() DecodeOption {
 	}
 }
 
+// UseOrderedMap can be interpreted as a map,
+// and uses MapSlice ( ordered map ) aggressively if there is no type specification
+func UseOrderedMap() DecodeOption {
+	return func(d *Decoder) error {
+		d.useOrderedMap = true
+		return nil
+	}
+}
+
 // EncodeOption functional option type for Encoder
 type EncodeOption func(e *Encoder) error
 


### PR DESCRIPTION
### How to Use

```go
yml := `
a: b
c: d
e:
  f: g
  h: i
j: k
`
var v interface{}
yaml.NewDecoder(strings.NewReader(yml), yaml.UseOrderedMap()).Decode(&v)
```

### Output

`v` is the following

```
yaml.MapSlice{
  yaml.MapItem{
    Key:   "a",
    Value: "b",
  },
  yaml.MapItem{
    Key:   "c",
    Value: "d",
  },
  yaml.MapItem{
    Key:   "e",
    Value: yaml.MapSlice{
      yaml.MapItem{
        Key:   "f",
        Value: "g",
      },
      yaml.MapItem{
        Key:   "h",
        Value: "i",
      },
    },
  },
  yaml.MapItem{
    Key:   "j",
    Value: "k",
  },
}
```

Then, `yaml.Marshal(v)` output **SAME** result 🎉 