### PR TITLE
Add new convenient APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ b: "hello"
     if err != nil {
       panic(err)
     }
-    source, err := path.AddAnnotationToSource([]byte(yml), true)
+    source, err := path.AnnotateSource([]byte(yml), true)
     if err != nil {
       panic(err)
     }
@@ -337,7 +337,7 @@ b: "hello"
 }
 ```
 
-output result is following 
+output result is the following.
 
 <img src="https://user-images.githubusercontent.com/209884/84148813-7aca8680-aa9a-11ea-8fc9-37dece2ebdac.png"></img>
 

--- a/README.md
+++ b/README.md
@@ -308,26 +308,7 @@ import (
   "fmt"
 
   "github.com/goccy/go-yaml"
-  "github.com/goccy/go-yaml/parser"
-  "github.com/goccy/go-yaml/printer"
 )
-
-func yamlSourceByPath(originalSource string, pathStr string) (string, error) {
-  file, err := parser.ParseBytes([]byte(originalSource), 0)
-  if err != nil {
-    return "", err
-  }
-  path, err := yaml.PathString(pathStr)
-  if err != nil {
-    return "", err
-  }
-  node, err := path.FilterFile(file)
-  if err != nil {
-    return "", err
-  }
-  var p printer.Printer
-  return p.PrintErrorToken(node.GetToken(), true), nil
-}
 
 func main() {
   yml := `
@@ -343,17 +324,18 @@ b: "hello"
   }
   if v.A != 2 {
     // output error with YAML source
-    source, err := yamlSourceByPath(yml, "$.a")
+    path, err := yaml.PathString("$.a")
     if err != nil {
       panic(err)
     }
-    fmt.Printf("a value expected 2 but actual %d:\n%s\n", v.A, source)
+    source, err := path.AddAnnotationToSource([]byte(yml), true)
+    if err != nil {
+      panic(err)
+    }
+    fmt.Printf("a value expected 2 but actual %d:\n%s\n", v.A, string(source))
   }
 }
 ```
-
-`printer.PrintErrorToken` can output YAML source with error point,
-and you can get `token.Token` of error point by `yaml.Path` .
 
 output result is following 
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -901,6 +901,13 @@ type MappingNode struct {
 	Values      []*MappingValueNode
 }
 
+func (n *MappingNode) startPos() *token.Position {
+	if len(n.Values) == 0 {
+		return n.Start.Position
+	}
+	return n.Values[0].Key.GetToken().Position
+}
+
 // Merge merge key/value of map.
 func (n *MappingNode) Merge(target *MappingNode) {
 	keyToMapValueMap := map[string]*MappingValueNode{}
@@ -908,7 +915,7 @@ func (n *MappingNode) Merge(target *MappingNode) {
 		key := value.Key.String()
 		keyToMapValueMap[key] = value
 	}
-	column := n.Start.Position.Column - target.Start.Position.Column
+	column := n.startPos().Column - target.startPos().Column
 	target.AddColumn(column)
 	for _, value := range target.Values {
 		mapValue, exists := keyToMapValueMap[value.Key.String()]

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -109,6 +110,7 @@ func (t NodeType) String() string {
 
 // Node type of node
 type Node interface {
+	io.Reader
 	// String node to text
 	String() string
 	// GetToken returns token instance
@@ -121,71 +123,10 @@ type Node interface {
 	SetComment(*token.Token) error
 	// Comment returns comment token instance
 	GetComment() *token.Token
-}
-
-// File contains all documents in YAML file
-type File struct {
-	Name string
-	Docs []*Document
-}
-
-// String all documents to text
-func (f *File) String() string {
-	docs := []string{}
-	for _, doc := range f.Docs {
-		docs = append(docs, doc.String())
-	}
-	return strings.Join(docs, "\n")
-}
-
-// Document type of Document
-type Document struct {
-	Comment *token.Token // position of Comment ( `#comment` )
-	Start   *token.Token // position of DocumentHeader ( `---` )
-	End     *token.Token // position of DocumentEnd ( `...` )
-	Body    Node
-}
-
-// GetToken returns token instance
-func (d *Document) GetToken() *token.Token {
-	return d.Body.GetToken()
-}
-
-// GetComment returns comment token instance
-func (d *Document) GetComment() *token.Token {
-	return d.Comment
-}
-
-// AddColumn add column number to child nodes recursively
-func (d *Document) AddColumn(col int) {
-	if d.Body != nil {
-		d.Body.AddColumn(col)
-	}
-}
-
-// SetComment set comment token
-func (d *Document) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	d.Comment = tk
-	return nil
-}
-
-// Type returns DocumentType
-func (d *Document) Type() NodeType { return DocumentType }
-
-// String document to text
-func (d *Document) String() string {
-	doc := []string{}
-	if d.Start != nil {
-		doc = append(doc, d.Start.Value)
-	}
-	doc = append(doc, d.Body.String())
-	if d.End != nil {
-		doc = append(doc, d.End.Value)
-	}
-	return strings.Join(doc, "\n")
+	// already read length
+	readLen() int
+	// append read length
+	addReadLen(int)
 }
 
 // ScalarNode type for scalar node
@@ -194,10 +135,60 @@ type ScalarNode interface {
 	GetValue() interface{}
 }
 
+type BaseNode struct {
+	Comment *token.Token
+	read    int
+}
+
+func (n *BaseNode) readLen() int {
+	return n.read
+}
+
+func (n *BaseNode) addReadLen(len int) {
+	n.read += len
+}
+
+// GetComment returns comment token instance
+func (n *BaseNode) GetComment() *token.Token {
+	return n.Comment
+}
+
+// SetComment set comment token
+func (n *BaseNode) SetComment(tk *token.Token) error {
+	if tk.Type != token.CommentType {
+		return ErrInvalidTokenType
+	}
+	n.Comment = tk
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func readNode(p []byte, node Node) (int, error) {
+	s := node.String()
+	readLen := node.readLen()
+	remain := len(s) - readLen
+	if remain == 0 {
+		return 0, io.EOF
+	}
+	size := min(remain, len(p))
+	for idx, b := range s[readLen : readLen+size] {
+		p[idx] = byte(b)
+	}
+	node.addReadLen(size)
+	return size, nil
+}
+
 // Null create node for null value
 func Null(tk *token.Token) Node {
 	return &NullNode{
-		Token: tk,
+		BaseNode: &BaseNode{},
+		Token:    tk,
 	}
 }
 
@@ -205,13 +196,10 @@ func Null(tk *token.Token) Node {
 func Bool(tk *token.Token) Node {
 	b, _ := strconv.ParseBool(tk.Value)
 	return &BoolNode{
-		Token: tk,
-		Value: b,
+		BaseNode: &BaseNode{},
+		Token:    tk,
+		Value:    b,
 	}
-}
-
-func removeUnderScoreFromNumber(num string) string {
-	return strings.ReplaceAll(num, "_", "")
 }
 
 // Integer create node for integer value
@@ -228,10 +216,18 @@ func Integer(tk *token.Token) Node {
 		}
 		if len(negativePrefix) > 0 {
 			i, _ := strconv.ParseInt(negativePrefix+value[skipCharacterNum:], 2, 64)
-			return &IntegerNode{Token: tk, Value: i}
+			return &IntegerNode{
+				BaseNode: &BaseNode{},
+				Token:    tk,
+				Value:    i,
+			}
 		}
 		i, _ := strconv.ParseUint(negativePrefix+value[skipCharacterNum:], 2, 64)
-		return &IntegerNode{Token: tk, Value: i}
+		return &IntegerNode{
+			BaseNode: &BaseNode{},
+			Token:    tk,
+			Value:    i,
+		}
 	case token.OctetIntegerType:
 		// octet token starts with '0o' or '-0o' or '0' or '-0'
 		skipCharacterNum := 1
@@ -249,10 +245,18 @@ func Integer(tk *token.Token) Node {
 		}
 		if len(negativePrefix) > 0 {
 			i, _ := strconv.ParseInt(negativePrefix+value[skipCharacterNum:], 8, 64)
-			return &IntegerNode{Token: tk, Value: i}
+			return &IntegerNode{
+				BaseNode: &BaseNode{},
+				Token:    tk,
+				Value:    i,
+			}
 		}
 		i, _ := strconv.ParseUint(value[skipCharacterNum:], 8, 64)
-		return &IntegerNode{Token: tk, Value: i}
+		return &IntegerNode{
+			BaseNode: &BaseNode{},
+			Token:    tk,
+			Value:    i,
+		}
 	case token.HexIntegerType:
 		// hex token starts with '0x' or '-0x'
 		skipCharacterNum := 2
@@ -263,32 +267,50 @@ func Integer(tk *token.Token) Node {
 		}
 		if len(negativePrefix) > 0 {
 			i, _ := strconv.ParseInt(negativePrefix+value[skipCharacterNum:], 16, 64)
-			return &IntegerNode{Token: tk, Value: i}
+			return &IntegerNode{
+				BaseNode: &BaseNode{},
+				Token:    tk,
+				Value:    i,
+			}
 		}
 		i, _ := strconv.ParseUint(value[skipCharacterNum:], 16, 64)
-		return &IntegerNode{Token: tk, Value: i}
+		return &IntegerNode{
+			BaseNode: &BaseNode{},
+			Token:    tk,
+			Value:    i,
+		}
 	}
 	if value[0] == '-' || value[0] == '+' {
 		i, _ := strconv.ParseInt(value, 10, 64)
-		return &IntegerNode{Token: tk, Value: i}
+		return &IntegerNode{
+			BaseNode: &BaseNode{},
+			Token:    tk,
+			Value:    i,
+		}
 	}
 	i, _ := strconv.ParseUint(value, 10, 64)
-	return &IntegerNode{Token: tk, Value: i}
+	return &IntegerNode{
+		BaseNode: &BaseNode{},
+		Token:    tk,
+		Value:    i,
+	}
 }
 
 // Float create node for float value
 func Float(tk *token.Token) Node {
 	f, _ := strconv.ParseFloat(removeUnderScoreFromNumber(tk.Value), 64)
 	return &FloatNode{
-		Token: tk,
-		Value: f,
+		BaseNode: &BaseNode{},
+		Token:    tk,
+		Value:    f,
 	}
 }
 
 // Infinity create node for .inf or -.inf value
-func Infinity(tk *token.Token) Node {
+func Infinity(tk *token.Token) *InfinityNode {
 	node := &InfinityNode{
-		Token: tk,
+		BaseNode: &BaseNode{},
+		Token:    tk,
 	}
 	switch tk.Value {
 	case ".inf", ".Inf", ".INF":
@@ -300,60 +322,202 @@ func Infinity(tk *token.Token) Node {
 }
 
 // Nan create node for .nan value
-func Nan(tk *token.Token) Node {
-	return &NanNode{Token: tk}
+func Nan(tk *token.Token) *NanNode {
+	return &NanNode{
+		BaseNode: &BaseNode{},
+		Token:    tk,
+	}
 }
 
 // String create node for string value
-func String(tk *token.Token) Node {
+func String(tk *token.Token) *StringNode {
 	return &StringNode{
-		Token: tk,
-		Value: tk.Value,
+		BaseNode: &BaseNode{},
+		Token:    tk,
+		Value:    tk.Value,
 	}
 }
 
 // Comment create node for comment
-func Comment(tk *token.Token) Node {
-	return &CommentNode{Comment: tk}
+func Comment(tk *token.Token) *CommentNode {
+	return &CommentNode{
+		BaseNode: &BaseNode{Comment: tk},
+	}
 }
 
 // MergeKey create node for merge key ( << )
-func MergeKey(tk *token.Token) Node {
+func MergeKey(tk *token.Token) *MergeKeyNode {
 	return &MergeKeyNode{
-		Token: tk,
+		BaseNode: &BaseNode{},
+		Token:    tk,
 	}
 }
 
 // Mapping create node for map
-func Mapping(tk *token.Token, isFlowStyle bool) *MappingNode {
-	return &MappingNode{
+func Mapping(tk *token.Token, isFlowStyle bool, values ...*MappingValueNode) *MappingNode {
+	node := &MappingNode{
+		BaseNode:    &BaseNode{},
 		Start:       tk,
 		IsFlowStyle: isFlowStyle,
 		Values:      []*MappingValueNode{},
+	}
+	node.Values = append(node.Values, values...)
+	return node
+}
+
+// MappingValue create node for mapping value
+func MappingValue(tk *token.Token, key Node, value Node) *MappingValueNode {
+	return &MappingValueNode{
+		BaseNode: &BaseNode{},
+		Start:    tk,
+		Key:      key,
+		Value:    value,
 	}
 }
 
 // MappingKey create node for map key ( '?' ).
 func MappingKey(tk *token.Token) *MappingKeyNode {
 	return &MappingKeyNode{
-		Start: tk,
+		BaseNode: &BaseNode{},
+		Start:    tk,
 	}
 }
 
 // Sequence create node for sequence
 func Sequence(tk *token.Token, isFlowStyle bool) *SequenceNode {
 	return &SequenceNode{
+		BaseNode:    &BaseNode{},
 		Start:       tk,
 		IsFlowStyle: isFlowStyle,
 		Values:      []Node{},
 	}
 }
 
+func Anchor(tk *token.Token) *AnchorNode {
+	return &AnchorNode{
+		BaseNode: &BaseNode{},
+		Start:    tk,
+	}
+}
+
+func Alias(tk *token.Token) *AliasNode {
+	return &AliasNode{
+		BaseNode: &BaseNode{},
+		Start:    tk,
+	}
+}
+
+func Document(tk *token.Token, body Node) *DocumentNode {
+	return &DocumentNode{
+		BaseNode: &BaseNode{},
+		Start:    tk,
+		Body:     body,
+	}
+}
+
+func Directive(tk *token.Token) *DirectiveNode {
+	return &DirectiveNode{
+		BaseNode: &BaseNode{},
+		Start:    tk,
+	}
+}
+
+func Literal(tk *token.Token) *LiteralNode {
+	return &LiteralNode{
+		BaseNode: &BaseNode{},
+		Start:    tk,
+	}
+}
+
+func Tag(tk *token.Token) *TagNode {
+	return &TagNode{
+		BaseNode: &BaseNode{},
+		Start:    tk,
+	}
+}
+
+// File contains all documents in YAML file
+type File struct {
+	Name string
+	Docs []*DocumentNode
+}
+
+// Read implements (io.Reader).Read
+func (f *File) Read(p []byte) (int, error) {
+	for _, doc := range f.Docs {
+		n, err := doc.Read(p)
+		if err == io.EOF {
+			continue
+		}
+		return n, nil
+	}
+	return 0, io.EOF
+}
+
+// String all documents to text
+func (f *File) String() string {
+	docs := []string{}
+	for _, doc := range f.Docs {
+		docs = append(docs, doc.String())
+	}
+	return strings.Join(docs, "\n")
+}
+
+// DocumentNode type of Document
+type DocumentNode struct {
+	*BaseNode
+	Start *token.Token // position of DocumentHeader ( `---` )
+	End   *token.Token // position of DocumentEnd ( `...` )
+	Body  Node
+}
+
+// Read implements (io.Reader).Read
+func (d *DocumentNode) Read(p []byte) (int, error) {
+	return readNode(p, d)
+}
+
+// Type returns DocumentNodeType
+func (d *DocumentNode) Type() NodeType { return DocumentType }
+
+// GetToken returns token instance
+func (d *DocumentNode) GetToken() *token.Token {
+	return d.Body.GetToken()
+}
+
+// AddColumn add column number to child nodes recursively
+func (d *DocumentNode) AddColumn(col int) {
+	if d.Body != nil {
+		d.Body.AddColumn(col)
+	}
+}
+
+// String document to text
+func (d *DocumentNode) String() string {
+	doc := []string{}
+	if d.Start != nil {
+		doc = append(doc, d.Start.Value)
+	}
+	doc = append(doc, d.Body.String())
+	if d.End != nil {
+		doc = append(doc, d.End.Value)
+	}
+	return strings.Join(doc, "\n")
+}
+
+func removeUnderScoreFromNumber(num string) string {
+	return strings.ReplaceAll(num, "_", "")
+}
+
 // NullNode type of null node
 type NullNode struct {
-	ScalarNode
+	*BaseNode
 	Comment *token.Token // position of Comment ( `#comment` )
 	Token   *token.Token
+}
+
+// Read implements (io.Reader).Read
+func (n *NullNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns NullType
@@ -362,11 +526,6 @@ func (n *NullNode) Type() NodeType { return NullType }
 // GetToken returns token instance
 func (n *NullNode) GetToken() *token.Token {
 	return n.Token
-}
-
-// GetComment returns comment token instance
-func (n *NullNode) GetComment() *token.Token {
-	return n.Comment
 }
 
 // AddColumn add column number to child nodes recursively
@@ -395,10 +554,14 @@ func (n *NullNode) String() string {
 
 // IntegerNode type of integer node
 type IntegerNode struct {
-	ScalarNode
-	Comment *token.Token // position of Comment ( `#comment` )
-	Token   *token.Token
-	Value   interface{} // int64 or uint64 value
+	*BaseNode
+	Token *token.Token
+	Value interface{} // int64 or uint64 value
+}
+
+// Read implements (io.Reader).Read
+func (n *IntegerNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns IntegerType
@@ -409,23 +572,9 @@ func (n *IntegerNode) GetToken() *token.Token {
 	return n.Token
 }
 
-// GetComment returns comment token instance
-func (n *IntegerNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *IntegerNode) AddColumn(col int) {
 	n.Token.AddColumn(col)
-}
-
-// SetComment set comment token
-func (n *IntegerNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // GetValue returns int64 value
@@ -440,11 +589,15 @@ func (n *IntegerNode) String() string {
 
 // FloatNode type of float node
 type FloatNode struct {
-	ScalarNode
-	Comment   *token.Token // position of Comment ( `#comment` )
+	*BaseNode
 	Token     *token.Token
 	Precision int
 	Value     float64
+}
+
+// Read implements (io.Reader).Read
+func (n *FloatNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns FloatType
@@ -455,23 +608,9 @@ func (n *FloatNode) GetToken() *token.Token {
 	return n.Token
 }
 
-// GetComment returns comment token instance
-func (n *FloatNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *FloatNode) AddColumn(col int) {
 	n.Token.AddColumn(col)
-}
-
-// SetComment set comment token
-func (n *FloatNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // GetValue returns float64 value
@@ -486,10 +625,14 @@ func (n *FloatNode) String() string {
 
 // StringNode type of string node
 type StringNode struct {
-	ScalarNode
-	Comment *token.Token // position of Comment ( `#comment` )
-	Token   *token.Token
-	Value   string
+	*BaseNode
+	Token *token.Token
+	Value string
+}
+
+// Read implements (io.Reader).Read
+func (n *StringNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns StringType
@@ -500,23 +643,9 @@ func (n *StringNode) GetToken() *token.Token {
 	return n.Token
 }
 
-// GetComment returns comment token instance
-func (n *StringNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *StringNode) AddColumn(col int) {
 	n.Token.AddColumn(col)
-}
-
-// SetComment set comment token
-func (n *StringNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // GetValue returns string value
@@ -553,10 +682,14 @@ func (n *StringNode) String() string {
 
 // LiteralNode type of literal node
 type LiteralNode struct {
-	ScalarNode
-	Comment *token.Token // position of Comment ( `#comment` )
-	Start   *token.Token
-	Value   *StringNode
+	*BaseNode
+	Start *token.Token
+	Value *StringNode
+}
+
+// Read implements (io.Reader).Read
+func (n *LiteralNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns LiteralType
@@ -567,26 +700,12 @@ func (n *LiteralNode) GetToken() *token.Token {
 	return n.Start
 }
 
-// GetComment returns comment token instance
-func (n *LiteralNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *LiteralNode) AddColumn(col int) {
 	n.Start.AddColumn(col)
 	if n.Value != nil {
 		n.Value.AddColumn(col)
 	}
-}
-
-// SetComment set comment token
-func (n *LiteralNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // GetValue returns string value
@@ -602,9 +721,13 @@ func (n *LiteralNode) String() string {
 
 // MergeKeyNode type of merge key node
 type MergeKeyNode struct {
-	ScalarNode
-	Comment *token.Token // position of Comment ( `#comment` )
-	Token   *token.Token
+	*BaseNode
+	Token *token.Token
+}
+
+// Read implements (io.Reader).Read
+func (n *MergeKeyNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns MergeKeyType
@@ -613,11 +736,6 @@ func (n *MergeKeyNode) Type() NodeType { return MergeKeyType }
 // GetToken returns token instance
 func (n *MergeKeyNode) GetToken() *token.Token {
 	return n.Token
-}
-
-// GetComment returns comment token instance
-func (n *MergeKeyNode) GetComment() *token.Token {
-	return n.Comment
 }
 
 // GetValue returns '<<' value
@@ -635,21 +753,16 @@ func (n *MergeKeyNode) AddColumn(col int) {
 	n.Token.AddColumn(col)
 }
 
-// SetComment set comment token
-func (n *MergeKeyNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
-}
-
 // BoolNode type of boolean node
 type BoolNode struct {
-	ScalarNode
-	Comment *token.Token // position of Comment ( `#comment` )
-	Token   *token.Token
-	Value   bool
+	*BaseNode
+	Token *token.Token
+	Value bool
+}
+
+// Read implements (io.Reader).Read
+func (n *BoolNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns BoolType
@@ -660,23 +773,9 @@ func (n *BoolNode) GetToken() *token.Token {
 	return n.Token
 }
 
-// GetComment returns comment token instance
-func (n *BoolNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *BoolNode) AddColumn(col int) {
 	n.Token.AddColumn(col)
-}
-
-// SetComment set comment token
-func (n *BoolNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // GetValue returns boolean value
@@ -691,10 +790,14 @@ func (n *BoolNode) String() string {
 
 // InfinityNode type of infinity node
 type InfinityNode struct {
-	ScalarNode
-	Comment *token.Token // position of Comment ( `#comment` )
-	Token   *token.Token
-	Value   float64
+	*BaseNode
+	Token *token.Token
+	Value float64
+}
+
+// Read implements (io.Reader).Read
+func (n *InfinityNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns InfinityType
@@ -705,23 +808,9 @@ func (n *InfinityNode) GetToken() *token.Token {
 	return n.Token
 }
 
-// GetComment returns comment token instance
-func (n *InfinityNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *InfinityNode) AddColumn(col int) {
 	n.Token.AddColumn(col)
-}
-
-// SetComment set comment token
-func (n *InfinityNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // GetValue returns math.Inf(0) or math.Inf(-1)
@@ -736,9 +825,13 @@ func (n *InfinityNode) String() string {
 
 // NanNode type of nan node
 type NanNode struct {
-	ScalarNode
-	Comment *token.Token // position of Comment ( `#comment` )
-	Token   *token.Token
+	*BaseNode
+	Token *token.Token
+}
+
+// Read implements (io.Reader).Read
+func (n *NanNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns NanType
@@ -749,23 +842,9 @@ func (n *NanNode) GetToken() *token.Token {
 	return n.Token
 }
 
-// GetComment returns comment token instance
-func (n *NanNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *NanNode) AddColumn(col int) {
 	n.Token.AddColumn(col)
-}
-
-// SetComment set comment token
-func (n *NanNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // GetValue returns math.NaN()
@@ -813,11 +892,16 @@ func (m *MapNodeIter) Value() Node {
 
 // MappingNode type of mapping node
 type MappingNode struct {
-	Comment     *token.Token // position of Comment ( `#comment` )
+	*BaseNode
 	Start       *token.Token
 	End         *token.Token
 	IsFlowStyle bool
 	Values      []*MappingValueNode
+}
+
+// Read implements (io.Reader).Read
+func (n *MappingNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns MappingType
@@ -828,11 +912,6 @@ func (n *MappingNode) GetToken() *token.Token {
 	return n.Start
 }
 
-// GetComment returns comment token instance
-func (n *MappingNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *MappingNode) AddColumn(col int) {
 	n.Start.AddColumn(col)
@@ -840,15 +919,6 @@ func (n *MappingNode) AddColumn(col int) {
 	for _, value := range n.Values {
 		value.AddColumn(col)
 	}
-}
-
-// SetComment set comment token
-func (n *MappingNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 func (n *MappingNode) flowStyleString() string {
@@ -891,9 +961,14 @@ func (n *MappingNode) MapRange() *MapNodeIter {
 
 // MappingKeyNode type of tag node
 type MappingKeyNode struct {
-	Comment *token.Token // position of Comment ( `#comment` )
-	Start   *token.Token
-	Value   Node
+	*BaseNode
+	Start *token.Token
+	Value Node
+}
+
+// Read implements (io.Reader).Read
+func (n *MappingKeyNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns MappingKeyType
@@ -904,26 +979,12 @@ func (n *MappingKeyNode) GetToken() *token.Token {
 	return n.Start
 }
 
-// GetComment returns comment token instance
-func (n *MappingKeyNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *MappingKeyNode) AddColumn(col int) {
 	n.Start.AddColumn(col)
 	if n.Value != nil {
 		n.Value.AddColumn(col)
 	}
-}
-
-// SetComment set comment token
-func (n *MappingKeyNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // String tag to text
@@ -933,10 +994,15 @@ func (n *MappingKeyNode) String() string {
 
 // MappingValueNode type of mapping value
 type MappingValueNode struct {
-	Comment *token.Token // position of Comment ( `#comment` )
-	Start   *token.Token
-	Key     Node
-	Value   Node
+	*BaseNode
+	Start *token.Token
+	Key   Node
+	Value Node
+}
+
+// Read implements (io.Reader).Read
+func (n *MappingValueNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns MappingValueType
@@ -945,11 +1011,6 @@ func (n *MappingValueNode) Type() NodeType { return MappingValueType }
 // GetToken returns token instance
 func (n *MappingValueNode) GetToken() *token.Token {
 	return n.Start
-}
-
-// GetComment returns comment token instance
-func (n *MappingValueNode) GetComment() *token.Token {
-	return n.Comment
 }
 
 // AddColumn add column number to child nodes recursively
@@ -961,15 +1022,6 @@ func (n *MappingValueNode) AddColumn(col int) {
 	if n.Value != nil {
 		n.Value.AddColumn(col)
 	}
-}
-
-// SetComment set comment token
-func (n *MappingValueNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // String mapping value to text
@@ -1032,11 +1084,16 @@ func (m *ArrayNodeIter) Len() int {
 
 // SequenceNode type of sequence node
 type SequenceNode struct {
-	Comment     *token.Token // position of Comment ( `#comment` )
+	*BaseNode
 	Start       *token.Token
 	End         *token.Token
 	IsFlowStyle bool
 	Values      []Node
+}
+
+// Read implements (io.Reader).Read
+func (n *SequenceNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns SequenceType
@@ -1047,11 +1104,6 @@ func (n *SequenceNode) GetToken() *token.Token {
 	return n.Start
 }
 
-// GetComment returns comment token instance
-func (n *SequenceNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *SequenceNode) AddColumn(col int) {
 	n.Start.AddColumn(col)
@@ -1059,15 +1111,6 @@ func (n *SequenceNode) AddColumn(col int) {
 	for _, value := range n.Values {
 		value.AddColumn(col)
 	}
-}
-
-// SetComment set comment token
-func (n *SequenceNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 func (n *SequenceNode) flowStyleString() string {
@@ -1120,10 +1163,15 @@ func (n *SequenceNode) ArrayRange() *ArrayNodeIter {
 
 // AnchorNode type of anchor node
 type AnchorNode struct {
-	Comment *token.Token // position of Comment ( `#comment` )
-	Start   *token.Token
-	Name    Node
-	Value   Node
+	*BaseNode
+	Start *token.Token
+	Name  Node
+	Value Node
+}
+
+// Read implements (io.Reader).Read
+func (n *AnchorNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns AnchorType
@@ -1132,11 +1180,6 @@ func (n *AnchorNode) Type() NodeType { return AnchorType }
 // GetToken returns token instance
 func (n *AnchorNode) GetToken() *token.Token {
 	return n.Start
-}
-
-// GetComment returns comment token instance
-func (n *AnchorNode) GetComment() *token.Token {
-	return n.Comment
 }
 
 // AddColumn add column number to child nodes recursively
@@ -1148,15 +1191,6 @@ func (n *AnchorNode) AddColumn(col int) {
 	if n.Value != nil {
 		n.Value.AddColumn(col)
 	}
-}
-
-// SetComment set comment token
-func (n *AnchorNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // String anchor to text
@@ -1174,9 +1208,14 @@ func (n *AnchorNode) String() string {
 
 // AliasNode type of alias node
 type AliasNode struct {
-	Comment *token.Token // position of Comment ( `#comment` )
-	Start   *token.Token
-	Value   Node
+	*BaseNode
+	Start *token.Token
+	Value Node
+}
+
+// Read implements (io.Reader).Read
+func (n *AliasNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns AliasType
@@ -1187,26 +1226,12 @@ func (n *AliasNode) GetToken() *token.Token {
 	return n.Start
 }
 
-// GetComment returns comment token instance
-func (n *AliasNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *AliasNode) AddColumn(col int) {
 	n.Start.AddColumn(col)
 	if n.Value != nil {
 		n.Value.AddColumn(col)
 	}
-}
-
-// SetComment set comment token
-func (n *AliasNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // String alias to text
@@ -1216,9 +1241,14 @@ func (n *AliasNode) String() string {
 
 // DirectiveNode type of directive node
 type DirectiveNode struct {
-	Comment *token.Token // position of Comment ( `#comment` )
-	Start   *token.Token
-	Value   Node
+	*BaseNode
+	Start *token.Token
+	Value Node
+}
+
+// Read implements (io.Reader).Read
+func (n *DirectiveNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns DirectiveType
@@ -1229,25 +1259,11 @@ func (n *DirectiveNode) GetToken() *token.Token {
 	return n.Start
 }
 
-// GetComment returns comment token instance
-func (n *DirectiveNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *DirectiveNode) AddColumn(col int) {
 	if n.Value != nil {
 		n.Value.AddColumn(col)
 	}
-}
-
-// SetComment set comment token
-func (n *DirectiveNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // String directive to text
@@ -1257,9 +1273,14 @@ func (n *DirectiveNode) String() string {
 
 // TagNode type of tag node
 type TagNode struct {
-	Comment *token.Token // position of Comment ( `#comment` )
-	Start   *token.Token
-	Value   Node
+	*BaseNode
+	Start *token.Token
+	Value Node
+}
+
+// Read implements (io.Reader).Read
+func (n *TagNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns TagType
@@ -1270,26 +1291,12 @@ func (n *TagNode) GetToken() *token.Token {
 	return n.Start
 }
 
-// GetComment returns comment token instance
-func (n *TagNode) GetComment() *token.Token {
-	return n.Comment
-}
-
 // AddColumn add column number to child nodes recursively
 func (n *TagNode) AddColumn(col int) {
 	n.Start.AddColumn(col)
 	if n.Value != nil {
 		n.Value.AddColumn(col)
 	}
-}
-
-// SetComment set comment token
-func (n *TagNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // String tag to text
@@ -1299,7 +1306,12 @@ func (n *TagNode) String() string {
 
 // CommentNode type of comment node
 type CommentNode struct {
-	Comment *token.Token // position of Comment ( `#comment` )
+	*BaseNode
+}
+
+// Read implements (io.Reader).Read
+func (n *CommentNode) Read(p []byte) (int, error) {
+	return readNode(p, n)
 }
 
 // Type returns TagType
@@ -1308,21 +1320,9 @@ func (n *CommentNode) Type() NodeType { return CommentType }
 // GetToken returns token instance
 func (n *CommentNode) GetToken() *token.Token { return n.Comment }
 
-// GetComment returns comment token instance
-func (n *CommentNode) GetComment() *token.Token { return n.Comment }
-
 // AddColumn add column number to child nodes recursively
 func (n *CommentNode) AddColumn(col int) {
 	n.Comment.AddColumn(col)
-}
-
-// SetComment set comment token
-func (n *CommentNode) SetComment(tk *token.Token) error {
-	if tk.Type != token.CommentType {
-		return ErrInvalidTokenType
-	}
-	n.Comment = tk
-	return nil
 }
 
 // String comment to text

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -12,7 +12,9 @@ import (
 )
 
 var (
-	ErrInvalidTokenType = xerrors.New("invalid token type")
+	ErrInvalidTokenType  = xerrors.New("invalid token type")
+	ErrInvalidAnchorName = xerrors.New("invalid anchor name")
+	ErrInvalidAliasName  = xerrors.New("invalid alias name")
 )
 
 // NodeType type identifier of node
@@ -1169,6 +1171,18 @@ type AnchorNode struct {
 	Value Node
 }
 
+func (n *AnchorNode) SetName(name string) error {
+	if n.Name == nil {
+		return ErrInvalidAnchorName
+	}
+	s, ok := n.Name.(*StringNode)
+	if !ok {
+		return ErrInvalidAnchorName
+	}
+	s.Value = name
+	return nil
+}
+
 // Read implements (io.Reader).Read
 func (n *AnchorNode) Read(p []byte) (int, error) {
 	return readNode(p, n)
@@ -1211,6 +1225,18 @@ type AliasNode struct {
 	*BaseNode
 	Start *token.Token
 	Value Node
+}
+
+func (n *AliasNode) SetName(name string) error {
+	if n.Value == nil {
+		return ErrInvalidAliasName
+	}
+	s, ok := n.Value.(*StringNode)
+	if !ok {
+		return ErrInvalidAliasName
+	}
+	s.Value = name
+	return nil
 }
 
 // Read implements (io.Reader).Read

--- a/decode.go
+++ b/decode.go
@@ -861,10 +861,8 @@ func (d *Decoder) decodeStruct(dst reflect.Value, src ast.Node) error {
 			}
 			mapNode := ast.Mapping(nil, false)
 			for k, v := range keyToNodeMap {
-				mapNode.Values = append(mapNode.Values, &ast.MappingValueNode{
-					Key:   &ast.StringNode{Value: k},
-					Value: v,
-				})
+				key := &ast.StringNode{BaseNode: &ast.BaseNode{}, Value: k}
+				mapNode.Values = append(mapNode.Values, ast.MappingValue(nil, key, v))
 			}
 			newFieldValue, err := d.createDecodedNewValue(fieldValue.Type(), mapNode)
 			if d.disallowUnknownField {

--- a/decode_test.go
+++ b/decode_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/parser"
 	"golang.org/x/xerrors"
 )
 
@@ -2201,5 +2202,29 @@ func TestDecoder_Canonical(t *testing.T) {
 	}
 	if m["null"] != nil {
 		t.Fatalf("failed to decode canonical yaml: %+v", m)
+	}
+}
+
+func TestDecoder_DecodeFromFile(t *testing.T) {
+	yml := `
+a: b
+c: d
+`
+	file, err := parser.ParseBytes([]byte(yml), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var v map[string]string
+	if err := yaml.NewDecoder(file).Decode(&v); err != nil {
+		t.Fatal(err)
+	}
+	if len(v) != 2 {
+		t.Fatal("failed to decode from ast.File")
+	}
+	if v["a"] != "b" {
+		t.Fatal("failed to decode from ast.File")
+	}
+	if v["c"] != "d" {
+		t.Fatal("failed to decode from ast.File")
 	}
 }

--- a/encode.go
+++ b/encode.go
@@ -68,18 +68,27 @@ func (e *Encoder) Close() error {
 //
 // See the documentation for Marshal for details about the conversion of Go values to YAML.
 func (e *Encoder) Encode(v interface{}) error {
-	for _, opt := range e.opts {
-		if err := opt(e); err != nil {
-			return errors.Wrapf(err, "failed to run option for encoder")
-		}
-	}
-	node, err := e.encodeValue(reflect.ValueOf(v), 1)
+	node, err := e.EncodeToNode(v)
 	if err != nil {
-		return errors.Wrapf(err, "failed to encode value")
+		return errors.Wrapf(err, "failed to encode to node")
 	}
 	var p printer.Printer
 	e.writer.Write(p.PrintNode(node))
 	return nil
+}
+
+// EncodeToNode convert v to ast.Node.
+func (e *Encoder) EncodeToNode(v interface{}) (ast.Node, error) {
+	for _, opt := range e.opts {
+		if err := opt(e); err != nil {
+			return nil, errors.Wrapf(err, "failed to run option for encoder")
+		}
+	}
+	node, err := e.encodeValue(reflect.ValueOf(v), 1)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to encode value")
+	}
+	return node, nil
 }
 
 func (e *Encoder) encodeDocument(doc []byte) (ast.Node, error) {

--- a/path.go
+++ b/path.go
@@ -226,8 +226,8 @@ func (p *Path) FilterNode(node ast.Node) (ast.Node, error) {
 	return n, nil
 }
 
-// AddAnnotationToSource add annotation to passed source ( see section 5.1 in README.md ).
-func (p *Path) AddAnnotationToSource(source []byte, colored bool) ([]byte, error) {
+// AnnotateSource add annotation to passed source ( see section 5.1 in README.md ).
+func (p *Path) AnnotateSource(source []byte, colored bool) ([]byte, error) {
 	file, err := parser.ParseBytes([]byte(source), 0)
 	if err != nil {
 		return nil, err

--- a/path_test.go
+++ b/path_test.go
@@ -114,7 +114,7 @@ store:
 	})
 }
 
-func ExamplePath_AddAnnotationToSource() {
+func ExamplePath_AnnotateSource() {
 	yml := `
 a: 1
 b: "hello"
@@ -132,7 +132,7 @@ b: "hello"
 		if err != nil {
 			log.Fatal(err)
 		}
-		source, err := path.AddAnnotationToSource([]byte(yml), false)
+		source, err := path.AnnotateSource([]byte(yml), false)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/path_test.go
+++ b/path_test.go
@@ -114,7 +114,38 @@ store:
 	})
 }
 
-func Example_YAMLPath() {
+func ExamplePath_AddAnnotationToSource() {
+	yml := `
+a: 1
+b: "hello"
+`
+	var v struct {
+		A int
+		B string
+	}
+	if err := yaml.Unmarshal([]byte(yml), &v); err != nil {
+		panic(err)
+	}
+	if v.A != 2 {
+		// output error with YAML source
+		path, err := yaml.PathString("$.a")
+		if err != nil {
+			log.Fatal(err)
+		}
+		source, err := path.AddAnnotationToSource([]byte(yml), false)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("a value expected 2 but actual %d:\n%s\n", v.A, string(source))
+	}
+	// OUTPUT:
+	// a value expected 2 but actual 1:
+	// >  2 | a: 1
+	//           ^
+	//    3 | b: "hello"
+}
+
+func ExamplePath_PathString() {
 	yml := `
 store:
   book:

--- a/path_test.go
+++ b/path_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/parser"
 )
 
 func builder() *yaml.PathBuilder { return &yaml.PathBuilder{} }
@@ -112,6 +113,304 @@ store:
 			})
 		}
 	})
+}
+
+func TestPath_Merge(t *testing.T) {
+	tests := []struct {
+		path     string
+		dst      string
+		src      string
+		expected string
+	}{
+		{
+			"$.c",
+			`
+a: 1
+b: 2
+c:
+  d: 3
+  e: 4
+`,
+			`
+f: 5
+g: 6
+`,
+			`
+a: 1
+b: 2
+c:
+  d: 3
+  e: 4
+  f: 5
+  g: 6
+`,
+		},
+		{
+			"$.a.b",
+			`
+a:
+  b:
+   - 1
+   - 2
+`,
+			`
+- 3
+- map:
+   - 4
+   - 5
+`,
+			`
+a:
+  b:
+   - 1
+   - 2
+   - 3
+   - map:
+      - 4
+      - 5
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			path, err := yaml.PathString(test.path)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			t.Run("FromReader", func(t *testing.T) {
+				file, err := parser.ParseBytes([]byte(test.dst), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				if err := path.MergeFromReader(file, strings.NewReader(test.src)); err != nil {
+					t.Fatalf("%+v", err)
+				}
+				actual := "\n" + file.String() + "\n"
+				if test.expected != actual {
+					t.Fatalf("expected: %q. but got %q", test.expected, actual)
+				}
+			})
+			t.Run("FromFile", func(t *testing.T) {
+				file, err := parser.ParseBytes([]byte(test.dst), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				src, err := parser.ParseBytes([]byte(test.src), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				if err := path.MergeFromFile(file, src); err != nil {
+					t.Fatalf("%+v", err)
+				}
+				actual := "\n" + file.String() + "\n"
+				if test.expected != actual {
+					t.Fatalf("expected: %q. but got %q", test.expected, actual)
+				}
+			})
+			t.Run("FromNode", func(t *testing.T) {
+				file, err := parser.ParseBytes([]byte(test.dst), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				src, err := parser.ParseBytes([]byte(test.src), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				if len(src.Docs) == 0 {
+					t.Fatalf("failed to parse")
+				}
+				if err := path.MergeFromNode(file, src.Docs[0]); err != nil {
+					t.Fatalf("%+v", err)
+				}
+				actual := "\n" + file.String() + "\n"
+				if test.expected != actual {
+					t.Fatalf("expected: %q. but got %q", test.expected, actual)
+				}
+			})
+		})
+	}
+}
+
+func TestPath_Replace(t *testing.T) {
+	tests := []struct {
+		path     string
+		dst      string
+		src      string
+		expected string
+	}{
+		{
+			"$.a",
+			`
+a: 1
+b: 2
+`,
+			`3`,
+			`
+a: 3
+b: 2
+`,
+		},
+		{
+			"$.b",
+			`
+b: 1
+c: 2
+`,
+			`
+d: e
+f:
+  g: h
+  i: j
+`,
+			`
+b:
+  d: e
+  f:
+    g: h
+    i: j
+c: 2
+`,
+		},
+		{
+			"$.a.b[0]",
+			`
+a:
+  b:
+  - hello
+c: 2
+`,
+			`world`,
+			`
+a:
+  b:
+  - world
+c: 2
+`,
+		},
+
+		{
+			"$.books[*].author",
+			`
+books:
+  - name: book_a
+    author: none
+  - name: book_b
+    author: none
+pictures:
+  - name: picture_a
+    author: none
+  - name: picture_b
+    author: none
+building:
+  author: none
+`,
+			`ken`,
+			`
+books:
+  - name: book_a
+    author: ken
+  - name: book_b
+    author: ken
+pictures:
+  - name: picture_a
+    author: none
+  - name: picture_b
+    author: none
+building:
+  author: none
+`,
+		},
+		{
+			"$..author",
+			`
+books:
+  - name: book_a
+    author: none
+  - name: book_b
+    author: none
+pictures:
+  - name: picture_a
+    author: none
+  - name: picture_b
+    author: none
+building:
+  author: none
+`,
+			`ken`,
+			`
+books:
+  - name: book_a
+    author: ken
+  - name: book_b
+    author: ken
+pictures:
+  - name: picture_a
+    author: ken
+  - name: picture_b
+    author: ken
+building:
+  author: ken
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			path, err := yaml.PathString(test.path)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			t.Run("WithReader", func(t *testing.T) {
+				file, err := parser.ParseBytes([]byte(test.dst), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				if err := path.ReplaceWithReader(file, strings.NewReader(test.src)); err != nil {
+					t.Fatalf("%+v", err)
+				}
+				actual := "\n" + file.String() + "\n"
+				if test.expected != actual {
+					t.Fatalf("expected: %q. but got %q", test.expected, actual)
+				}
+			})
+			t.Run("WithFile", func(t *testing.T) {
+				file, err := parser.ParseBytes([]byte(test.dst), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				src, err := parser.ParseBytes([]byte(test.src), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				if err := path.ReplaceWithFile(file, src); err != nil {
+					t.Fatalf("%+v", err)
+				}
+				actual := "\n" + file.String() + "\n"
+				if test.expected != actual {
+					t.Fatalf("expected: %q. but got %q", test.expected, actual)
+				}
+			})
+			t.Run("WithNode", func(t *testing.T) {
+				file, err := parser.ParseBytes([]byte(test.dst), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				src, err := parser.ParseBytes([]byte(test.src), 0)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				if len(src.Docs) == 0 {
+					t.Fatalf("failed to parse")
+				}
+				if err := path.ReplaceWithNode(file, src.Docs[0]); err != nil {
+					t.Fatalf("%+v", err)
+				}
+				actual := "\n" + file.String() + "\n"
+				if test.expected != actual {
+					t.Fatalf("expected: %q. but got %q", test.expected, actual)
+				}
+			})
+		})
+	}
 }
 
 func ExamplePath_AnnotateSource() {

--- a/yaml.go
+++ b/yaml.go
@@ -43,6 +43,15 @@ type MapItem struct {
 // The order of keys is preserved when encoding and decoding.
 type MapSlice []MapItem
 
+// ToMap convert to map[interface{}]interface{}.
+func (s MapSlice) ToMap() map[interface{}]interface{} {
+	v := map[interface{}]interface{}{}
+	for _, item := range s {
+		v[item.Key] = item.Value
+	}
+	return v
+}
+
 // Marshal serializes the value provided into a YAML document. The structure
 // of the generated document will reflect the structure of the value itself.
 // Maps and pointers (to struct, string, int, etc) are accepted as the in value.

--- a/yaml.go
+++ b/yaml.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/internal/errors"
 	"golang.org/x/xerrors"
 )
@@ -114,6 +115,16 @@ func MarshalWithOptions(v interface{}, opts ...EncodeOption) ([]byte, error) {
 		return nil, errors.Wrapf(err, "failed to marshal")
 	}
 	return buf.Bytes(), nil
+}
+
+// ValueToNode convert from value to ast.Node.
+func ValueToNode(v interface{}, opts ...EncodeOption) (ast.Node, error) {
+	var buf bytes.Buffer
+	node, err := NewEncoder(&buf, opts...).EncodeToNode(v)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to convert value to node")
+	}
+	return node, nil
 }
 
 // Unmarshal decodes the first document found within the in byte slice

--- a/yaml.go
+++ b/yaml.go
@@ -103,8 +103,13 @@ func (s MapSlice) ToMap() map[interface{}]interface{} {
 //     yaml.Marshal(&T{F: 1}) // Returns "a: 1\nb: 0\n"
 //
 func Marshal(v interface{}) ([]byte, error) {
+	return MarshalWithOptions(v)
+}
+
+// MarshalWithOptions serializes the value provided into a YAML document with EncodeOptions.
+func MarshalWithOptions(v interface{}, opts ...EncodeOption) ([]byte, error) {
 	var buf bytes.Buffer
-	enc := NewEncoder(&buf)
+	enc := NewEncoder(&buf, opts...)
 	if err := enc.Encode(v); err != nil {
 		return nil, errors.Wrapf(err, "failed to marshal")
 	}
@@ -135,7 +140,13 @@ func Marshal(v interface{}) ([]byte, error) {
 // supported tag options.
 //
 func Unmarshal(data []byte, v interface{}) error {
-	dec := NewDecoder(bytes.NewBuffer(data))
+	return UnmarshalWithOptions(data, v)
+}
+
+// UnmarshalWithOptions decodes with DecodeOptions the first document found within the in byte slice
+// and assigns decoded values into the out value.
+func UnmarshalWithOptions(data []byte, v interface{}, opts ...DecodeOption) error {
+	dec := NewDecoder(bytes.NewBuffer(data), opts...)
 	if err := dec.Decode(v); err != nil {
 		if err == io.EOF {
 			return nil
@@ -160,5 +171,4 @@ func FormatError(e error, colored, inclSource bool) string {
 	}
 
 	return e.Error()
-
 }

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -263,11 +263,11 @@ collection:
 `
 	var v rootObject
 	if err := yaml.Unmarshal([]byte(yml), &v); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	opt := yaml.MarshalAnchor(func(anchor *ast.AnchorNode, value interface{}) error {
 		if o, ok := value.(*ObjectDecl); ok {
-			anchor.Name.(*ast.StringNode).Value = o.Name
+			return anchor.SetName(o.Name)
 		}
 		return nil
 	})

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -301,3 +301,46 @@ c: d
 		t.Fatal("failed to convert MapSlice to map")
 	}
 }
+
+func TestMarshalWithModifiedAnchorAlias(t *testing.T) {
+	yml := `
+a: &a 1
+b: *a
+`
+	var v struct {
+		A *int `yaml:"a,anchor"`
+		B *int `yaml:"b,alias"`
+	}
+	if err := yaml.Unmarshal([]byte(yml), &v); err != nil {
+		t.Fatal(err)
+	}
+	node, err := yaml.ValueToNode(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	anchors := ast.Filter(ast.AnchorType, node)
+	if len(anchors) != 1 {
+		t.Fatal("failed to filter node")
+	}
+	anchor := anchors[0].(*ast.AnchorNode)
+	if err := anchor.SetName("b"); err != nil {
+		t.Fatal(err)
+	}
+	aliases := ast.Filter(ast.AliasType, node)
+	if len(anchors) != 1 {
+		t.Fatal("failed to filter node")
+	}
+	alias := aliases[0].(*ast.AliasNode)
+	if err := alias.SetName("b"); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `
+a: &b 1
+b: *b`
+
+	actual := "\n" + node.String()
+	if expected != actual {
+		t.Fatalf("failed to marshal: expected:[%q] but got [%q]", expected, actual)
+	}
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -280,3 +280,24 @@ collection:
 		t.Fatalf("failed to marshal: expected:[%s] actual:[%s]", yml, actual)
 	}
 }
+
+func TestMapSlice_Map(t *testing.T) {
+	yml := `
+a: b
+c: d
+`
+	var v yaml.MapSlice
+	if err := yaml.Unmarshal([]byte(yml), &v); err != nil {
+		t.Fatal(err)
+	}
+	m := v.ToMap()
+	if len(m) != 2 {
+		t.Fatal("failed to convert MapSlice to map")
+	}
+	if m["a"] != "b" {
+		t.Fatal("failed to convert MapSlice to map")
+	}
+	if m["c"] != "d" {
+		t.Fatal("failed to convert MapSlice to map")
+	}
+}


### PR DESCRIPTION
## New Features

### 1. Enable to pass `EncodeOption` or `DecodeOption` at `Marshal` or `Unmarshal`

- `yaml.MarshalWithOptions(v interface{}, opts ...EncodeOption) ([]byte, error)`
- `yaml.UnmarshalWithOptions(data []byte, v interface{}, opts ...DecodeOption) error`

### 2. Enable convert from `yaml.MapSlice` to `map[interface{}]interface{}`

- `(yaml.MapSlice).ToMap() map[interface{}]interface{}`

### 3. Enable to annotate source 

- `(*yaml.Path).AnnotateSource(source []byte, colored bool) ([]byte, error)`

### 4. Add `io.Reader` interface to `ast.Node`

`ast.Node` can be passed as the first argument of `NewDecoder()`

### 5. Available to filter `ast.Node`

- `ast.Filter(ast.NodeType, ast.Node) []ast.Node`
- `ast.FilterFile(ast.NodeType, *ast.File) []ast.Node`

### 6. Available to convert from `interface{}` to `ast.Node`

- `(*Encoder).EncodeToNode(interface{}) (ast.Node, error)`
- `ValueToNode(interface{}) (ast.Node, error)`

### 7. Availble **merge** and **replace** ast.Node

- `ast.Merge(dst ast.Node, src ast.Node) error`
- `(*yaml.Path).MergeFromNode(dst *ast.File, src ast.Node) error`
- `(*yaml.Path).ReplaceWithNode(dst *ast.File, node ast.Node) error`

and so on...

## **Breaking Changes**
- Rename `ast.Document` to `ast.DocumentNode`