### PR TITLE
Support use of encoding.TextUnmarshaler with anchors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -476,9 +476,12 @@ func (d *Decoder) decodeValue(dst reflect.Value, src ast.Node) error {
 	} else if _, ok := dst.Addr().Interface().(*time.Time); ok {
 		return d.decodeTime(dst, src)
 	} else if unmarshaler, isText := dst.Addr().Interface().(encoding.TextUnmarshaler); isText {
+		if anchor, isAnchor := src.(*ast.AnchorNode); isAnchor {
+			src = anchor.Value
+		}
 		var b string
 		if scalar, isScalar := src.(ast.ScalarNode); isScalar {
-			b = scalar.GetValue().(string)
+			b = fmt.Sprint(scalar.GetValue())
 		} else {
 			b = src.String()
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"math"
+	"net"
 	"reflect"
 	"strconv"
 	"strings"
@@ -865,6 +866,18 @@ func TestDecoder(t *testing.T) {
 			}{struct{ C int }{1}, struct{ C int }{1}},
 		},
 		{
+			"a: &x 1\nb: *x\nc: &y hello\nd: *y\n",
+			struct {
+				A, B, C, D unmarshalableStringValueWithUnmarshalText
+			}{"1", "1", "hello", "hello"},
+		},
+		{
+			"a: &a 127.0.0.1\nb: *a\n",
+			struct {
+				A, B net.IP
+			}{net.IPv4(127, 0, 0, 1), net.IPv4(127, 0, 0, 1)},
+		},
+		{
 			"a: &a [1, 2]\nb: *a\n",
 			struct{ B []int }{[]int{1, 2}},
 		},
@@ -996,6 +1009,13 @@ c:
 			t.Fatalf("failed to test [%s], actual=[%s], expect=[%s]", test.source, actual, expect)
 		}
 	}
+}
+
+type unmarshalableStringValueWithUnmarshalText string
+
+func (u *unmarshalableStringValueWithUnmarshalText) UnmarshalText(b []byte) error {
+	*u = unmarshalableStringValueWithUnmarshalText(b)
+	return nil
 }
 
 func TestDecoder_TypeConversionError(t *testing.T) {


### PR DESCRIPTION
`encoding.TextUnmarshaler` is intended to be "the interface implemented by an object that can unmarshal a textual representation of itself".

By providing the text without the anchor, this allows common types (e.g. `net.IP`, `big.Rat`) to be used as target values for decoding with anchors.

Without this change, the text "&a 1" would be used instead of "1":

	---
	a: &a 1
	b: *a