### PR TITLE
Bugfix/fix strict yaml struct validation

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -906,6 +906,16 @@ func (d *Decoder) decodeStruct(dst reflect.Value, src ast.Node) error {
 		}
 		fieldValue.Set(d.castToAssignableValue(newFieldValue, fieldValue.Type()))
 	}
+	if foundErr != nil {
+		return errors.Wrapf(foundErr, "failed to decode value")
+	}
+
+	if len(unknownFields) != 0 && d.disallowUnknownField {
+		for key, node := range unknownFields {
+			return errUnknownField(fmt.Sprintf(`unknown field "%s"`, key), node.GetToken())
+		}
+	}
+
 	if d.validator != nil {
 		if err := d.validator.Struct(dst.Interface()); err != nil {
 			ev := reflect.ValueOf(err)
@@ -928,14 +938,6 @@ func (d *Decoder) decodeStruct(dst reflect.Value, src ast.Node) error {
 				}
 			}
 		}
-	}
-	if len(unknownFields) != 0 && d.disallowUnknownField {
-		for key, node := range unknownFields {
-			return errUnknownField(fmt.Sprintf(`unknown field "%s"`, key), node.GetToken())
-		}
-	}
-	if foundErr != nil {
-		return errors.Wrapf(foundErr, "failed to decode value")
 	}
 	return nil
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -55,6 +55,32 @@ addr:
 				} `yaml:"addr"`
 			}{},
 		},
+		{
+			TestName: "Test nested Validation with unknown field",
+			YAMLContent: `---
+name: john
+age: 20
+addr:
+  number: seven
+  state: washington
+  error: error
+`,
+			ExpectedErr: `[7:3] unknown field "error"
+   4 | addr:
+   5 |   number: seven
+   6 |   state: washington
+>  7 |   error: error
+         ^
+`,
+			Instance: &struct {
+				Name string `yaml:"name" validate:"required"`
+				Age  int    `yaml:"age" validate:"gte=0,lt=120"`
+				Addr *struct {
+					Number string `yaml:"number" validate:"required"`
+					State  string `yaml:"state" validate:"required"`
+				} `yaml:"addr" validate:"required"`
+			}{},
+		},
 	}
 
 	for _, tc := range cases {
@@ -64,6 +90,7 @@ addr:
 			dec := yaml.NewDecoder(
 				strings.NewReader(tc.YAMLContent),
 				yaml.Validator(validate),
+				yaml.Strict(),
 			)
 			err := dec.Decode(tc.Instance)
 			switch {


### PR DESCRIPTION
Before changing the validation order in decode.go I got the following error:
```go
-- FAIL: TestStructValidator (0.00s)
    --- FAIL: TestStructValidator/Test_nested_Validation_with_unknown_field (0.00s)
        validate_test.go:102: expected `[7:3] unknown field "error"
               4 | addr:
               5 |   number: seven
               6 |   state: washington
            >  7 |   error: error
                     ^
            ` but actual `[5:9] Key: 'Addr' Error:Field validation for 'Addr' failed on the 'required' tag
               2 | name: john
               3 | age: 20
               4 | addr:
            >  5 |   number: seven
                           ^
               6 |   state: washington
               7 |   error: error`
FAIL
FAIL    command-line-arguments  0.443s
FAIL
```