### PR TITLE
bugfix: escape comments, anchors, aliases at the beginning of strings

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -574,7 +574,13 @@ func IsNeedQuoted(value string) bool {
 	if strings.IndexByte(value, ':') == 1 {
 		return true
 	}
-	if strings.IndexByte(value, '#') > 0 {
+	if strings.IndexByte(value, '#') >= 0 {
+		return true
+	}
+	if strings.IndexByte(value, '*') == 0 {
+		return true
+	}
+	if strings.IndexByte(value, '&') == 0 {
 		return true
 	}
 	for _, c := range value {

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -98,4 +98,13 @@ func TestIsNeedQuoted(t *testing.T) {
 	if token.IsNeedQuoted("Hello World") {
 		t.Fatal("failed to unquoted judge")
 	}
+	if !token.IsNeedQuoted("#Hello World") {
+		t.Fatal("failed to quoted judge for beginning comment")
+	}
+	if !token.IsNeedQuoted("*Hello World") {
+		t.Fatal("failed to quoted judge for beginning alias")
+	}
+	if !token.IsNeedQuoted("&Hello World") {
+		t.Fatal("failed to quoted judge for beginning anchor")
+	}
 }


### PR DESCRIPTION
this should fix #152  → the alias, anchor and comment bug, but I'm not sure whether there are other characters which should be quoted, too.
