### PR TITLE
ast: make Walk() type switch exhaustive

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1430,6 +1430,7 @@ func Walk(v Visitor, node Node) {
 	}
 
 	switch n := node.(type) {
+	case *CommentNode:
 	case *NullNode:
 	case *IntegerNode:
 	case *FloatNode:
@@ -1438,6 +1439,10 @@ func Walk(v Visitor, node Node) {
 	case *BoolNode:
 	case *InfinityNode:
 	case *NanNode:
+	case *LiteralNode:
+		Walk(v, n.Value)
+	case *DirectiveNode:
+		Walk(v, n.Value)
 	case *TagNode:
 		Walk(v, n.Value)
 	case *DocumentNode:


### PR DESCRIPTION
ast.Walk() was not entering some nodes.
This patch adds cases for nodes that were not handled.

The CommentNode case is not necessary, but it's added
for the completeness.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>