### PR TITLE
parser: fix parser panic for the invalid directive

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -390,7 +390,13 @@ func (p *parser) parseDirective(ctx *context) (ast.Node, error) {
 	}
 	node.Value = value
 	ctx.progress(1)
-	if ctx.currentToken().Type != token.DocumentHeaderType {
+	tk := ctx.currentToken()
+	if tk == nil {
+		// Since current token is nil, use the previous token to specify
+		// the syntax error location.
+		return nil, errors.ErrSyntax("unexpected directive value. document not started", ctx.previousToken())
+	}
+	if tk.Type != token.DocumentHeaderType {
 		return nil, errors.ErrSyntax("unexpected directive value. document not started", ctx.currentToken())
 	}
 	return node, nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -544,6 +544,7 @@ b: c
 `,
 		},
 	}
+
 	for _, test := range tests {
 		tokens := lexer.Tokenize(test.source)
 		f, err := parser.Parse(tokens, 0)
@@ -612,6 +613,14 @@ a
 >  2 | a
    3 | - b: c
        ^
+`,
+		},
+		{
+			`%YAML 1.1 {}`,
+			`
+[1:2] unexpected directive value. document not started
+>  1 | %YAML 1.1 {}
+        ^
 `,
 		},
 	}


### PR DESCRIPTION
`%YAML 1.1 {}` input makes the parser panic.

This change attempts to fix that by checking
for the token not to be nil. We use previous
token to specify the approx syntax error location.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>