### PR TITLE
Chomp folded style similar to literal style

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -980,6 +980,63 @@ c:
 			"v: あいうえお\nv2: かきくけこ",
 			map[string]string{"v": "あいうえお", "v2": "かきくけこ"},
 		},
+
+		// Chomping: literal style
+		{
+			`# Strip
+key: |-
+  value
+`,
+			map[string]string{
+				"key": "value",
+			},
+		},
+		{
+			`# Clip
+key: |
+  value
+`,
+			map[string]string{
+				"key": "value\n",
+			},
+		},
+		{
+			`# Keep
+key: |+
+  value
+`,
+			map[string]string{
+				"key": "value\n",
+			},
+		},
+		// Chomping: folded style
+		{
+			`# Strip
+key: >-
+  value
+`,
+			map[string]string{
+				"key": "value",
+			},
+		},
+		{
+			`# Clip
+key: >
+  value
+`,
+			map[string]string{
+				"key": "value\n",
+			},
+		},
+		{
+			`# Keep
+key: >+
+  value
+`,
+			map[string]string{
+				"key": "value\n",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.source, func(t *testing.T) {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -417,7 +417,7 @@ func (s *Scanner) scanComment(ctx *Context) (tk *token.Token, pos int) {
 func (s *Scanner) scanLiteral(ctx *Context, c rune) {
 	ctx.addOriginBuf(c)
 	if ctx.isEOS() {
-		if ctx.isLiteral {
+		if ctx.isLiteral || ctx.isFolded {
 			ctx.addBuf(c)
 		}
 		value := ctx.bufferedSrc()


### PR DESCRIPTION
From YAML 1.2 specification, [8.1.3. Folded Style](https://yaml.org/spec/1.2/spec.html#id2796251):

>The final line break, and trailing empty lines if any, are subject to chomping and are never folded.