### PR TITLE
Support MarshalWithContext and UnmarshalWithContext for passing context.Context to MarshalYAML and UnmarshalYAML

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -2,6 +2,7 @@ package yaml_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -1638,6 +1639,36 @@ func TestDecoder_UseJSONUnmarshaler(t *testing.T) {
 	}
 	if v.s != "a" {
 		t.Fatalf("unexpected decoded value: %s", v.s)
+	}
+}
+
+type unmarshalWithContext struct {
+	v int
+}
+
+func (c *unmarshalWithContext) UnmarshalYAML(ctx context.Context, b []byte) error {
+	v, ok := ctx.Value("k").(int)
+	if !ok {
+		return fmt.Errorf("cannot get valid context")
+	}
+	if v != 1 {
+		return fmt.Errorf("cannot get valid context")
+	}
+	if string(b) != "1" {
+		return fmt.Errorf("cannot get valid bytes")
+	}
+	c.v = v
+	return nil
+}
+
+func Test_UnmarshalerWithContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "k", 1)
+	var v unmarshalWithContext
+	if err := yaml.UnmarshalWithContext(ctx, []byte(`1`), &v); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if v.v != 1 {
+		t.Fatal("cannot call UnmarshalYAML")
 	}
 }
 

--- a/encode.go
+++ b/encode.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"context"
 	"encoding"
 	"fmt"
 	"io"
@@ -69,7 +70,12 @@ func (e *Encoder) Close() error {
 //
 // See the documentation for Marshal for details about the conversion of Go values to YAML.
 func (e *Encoder) Encode(v interface{}) error {
-	node, err := e.EncodeToNode(v)
+	return e.EncodeContext(context.Background(), v)
+}
+
+// EncodeContext writes the YAML encoding of v to the stream with context.Context.
+func (e *Encoder) EncodeContext(ctx context.Context, v interface{}) error {
+	node, err := e.EncodeToNodeContext(ctx, v)
 	if err != nil {
 		return errors.Wrapf(err, "failed to encode to node")
 	}
@@ -80,12 +86,17 @@ func (e *Encoder) Encode(v interface{}) error {
 
 // EncodeToNode convert v to ast.Node.
 func (e *Encoder) EncodeToNode(v interface{}) (ast.Node, error) {
+	return e.EncodeToNodeContext(context.Background(), v)
+}
+
+// EncodeToNodeContext convert v to ast.Node with context.Context.
+func (e *Encoder) EncodeToNodeContext(ctx context.Context, v interface{}) (ast.Node, error) {
 	for _, opt := range e.opts {
 		if err := opt(e); err != nil {
 			return nil, errors.Wrapf(err, "failed to run option for encoder")
 		}
 	}
-	node, err := e.encodeValue(reflect.ValueOf(v), 1)
+	node, err := e.encodeValue(ctx, reflect.ValueOf(v), 1)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to encode value")
 	}
@@ -123,57 +134,120 @@ type jsonMarshaler interface {
 	MarshalJSON() ([]byte, error)
 }
 
-func (e *Encoder) encodeValue(v reflect.Value, column int) (ast.Node, error) {
+func (e *Encoder) canEncodeByMarshaler(v reflect.Value) bool {
+	if !v.CanInterface() {
+		return false
+	}
+	iface := v.Interface()
+	switch iface.(type) {
+	case BytesMarshalerContext:
+		return true
+	case BytesMarshaler:
+		return true
+	case InterfaceMarshalerContext:
+		return true
+	case InterfaceMarshaler:
+		return true
+	case time.Time:
+		return true
+	case encoding.TextMarshaler:
+		return true
+	case jsonMarshaler:
+		return e.useJSONMarshaler
+	}
+	return false
+}
+
+func (e *Encoder) encodeByMarshaler(ctx context.Context, v reflect.Value, column int) (ast.Node, error) {
+	iface := v.Interface()
+
+	if marshaler, ok := iface.(BytesMarshalerContext); ok {
+		doc, err := marshaler.MarshalYAML(ctx)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to MarshalYAML")
+		}
+		node, err := e.encodeDocument(doc)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to encode document")
+		}
+		return node, nil
+	}
+
+	if marshaler, ok := iface.(BytesMarshaler); ok {
+		doc, err := marshaler.MarshalYAML()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to MarshalYAML")
+		}
+		node, err := e.encodeDocument(doc)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to encode document")
+		}
+		return node, nil
+	}
+
+	if marshaler, ok := iface.(InterfaceMarshalerContext); ok {
+		marshalV, err := marshaler.MarshalYAML(ctx)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to MarshalYAML")
+		}
+		return e.encodeValue(ctx, reflect.ValueOf(marshalV), column)
+	}
+
+	if marshaler, ok := iface.(InterfaceMarshaler); ok {
+		marshalV, err := marshaler.MarshalYAML()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to MarshalYAML")
+		}
+		return e.encodeValue(ctx, reflect.ValueOf(marshalV), column)
+	}
+
+	if t, ok := iface.(time.Time); ok {
+		return e.encodeTime(t, column), nil
+	}
+
+	if marshaler, ok := iface.(encoding.TextMarshaler); ok {
+		doc, err := marshaler.MarshalText()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to MarshalText")
+		}
+		node, err := e.encodeDocument(doc)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to encode document")
+		}
+		return node, nil
+	}
+
+	if e.useJSONMarshaler {
+		if marshaler, ok := iface.(jsonMarshaler); ok {
+			jsonBytes, err := marshaler.MarshalJSON()
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to MarshalJSON")
+			}
+			doc, err := JSONToYAML(jsonBytes)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to convert json to yaml")
+			}
+			node, err := e.encodeDocument(doc)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to encode document")
+			}
+			return node, nil
+		}
+	}
+
+	return nil, xerrors.Errorf("does not implemented Marshaler")
+}
+
+func (e *Encoder) encodeValue(ctx context.Context, v reflect.Value, column int) (ast.Node, error) {
 	if e.isInvalidValue(v) {
 		return e.encodeNil(), nil
 	}
-	if v.CanInterface() {
-		iface := v.Interface()
-		if marshaler, ok := iface.(BytesMarshaler); ok {
-			doc, err := marshaler.MarshalYAML()
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to MarshalYAML")
-			}
-			node, err := e.encodeDocument(doc)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to encode document")
-			}
-			return node, nil
-		} else if marshaler, ok := iface.(InterfaceMarshaler); ok {
-			marshalV, err := marshaler.MarshalYAML()
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to MarshalYAML")
-			}
-			return e.encodeValue(reflect.ValueOf(marshalV), column)
-		} else if t, ok := iface.(time.Time); ok {
-			return e.encodeTime(t, column), nil
-		} else if marshaler, ok := iface.(encoding.TextMarshaler); ok {
-			doc, err := marshaler.MarshalText()
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to MarshalText")
-			}
-			node, err := e.encodeDocument(doc)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to encode document")
-			}
-			return node, nil
-		} else if e.useJSONMarshaler {
-			if marshaler, ok := iface.(jsonMarshaler); ok {
-				jsonBytes, err := marshaler.MarshalJSON()
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to MarshalJSON")
-				}
-				doc, err := JSONToYAML(jsonBytes)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to convert json to yaml")
-				}
-				node, err := e.encodeDocument(doc)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to encode document")
-				}
-				return node, nil
-			}
+	if e.canEncodeByMarshaler(v) {
+		node, err := e.encodeByMarshaler(ctx, v, column)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to encode by marshaler")
 		}
+		return node, nil
 	}
 	switch v.Type().Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -190,30 +264,30 @@ func (e *Encoder) encodeValue(v reflect.Value, column int) (ast.Node, error) {
 			alias.Value = ast.String(token.New(aliasName, aliasName, e.pos(column)))
 			return alias, nil
 		}
-		return e.encodeValue(v.Elem(), column)
+		return e.encodeValue(ctx, v.Elem(), column)
 	case reflect.Interface:
-		return e.encodeValue(v.Elem(), column)
+		return e.encodeValue(ctx, v.Elem(), column)
 	case reflect.String:
 		return e.encodeString(v.String(), column), nil
 	case reflect.Bool:
 		return e.encodeBool(v.Bool()), nil
 	case reflect.Slice:
 		if mapSlice, ok := v.Interface().(MapSlice); ok {
-			return e.encodeMapSlice(mapSlice, column)
+			return e.encodeMapSlice(ctx, mapSlice, column)
 		}
-		return e.encodeSlice(v)
+		return e.encodeSlice(ctx, v)
 	case reflect.Struct:
 		if v.CanInterface() {
 			if mapItem, ok := v.Interface().(MapItem); ok {
-				return e.encodeMapItem(mapItem, column)
+				return e.encodeMapItem(ctx, mapItem, column)
 			}
 			if t, ok := v.Interface().(time.Time); ok {
 				return e.encodeTime(t, column), nil
 			}
 		}
-		return e.encodeStruct(v, column)
+		return e.encodeStruct(ctx, v, column)
 	case reflect.Map:
-		return e.encodeMap(v, column), nil
+		return e.encodeMap(ctx, v, column), nil
 	default:
 		return nil, xerrors.Errorf("unknown value type %s", v.Type().String())
 	}
@@ -284,10 +358,10 @@ func (e *Encoder) encodeBool(v bool) ast.Node {
 	return ast.Bool(token.New(value, value, e.pos(e.column)))
 }
 
-func (e *Encoder) encodeSlice(value reflect.Value) (ast.Node, error) {
+func (e *Encoder) encodeSlice(ctx context.Context, value reflect.Value) (ast.Node, error) {
 	sequence := ast.Sequence(token.New("-", "-", e.pos(e.column)), e.isFlowStyle)
 	for i := 0; i < value.Len(); i++ {
-		node, err := e.encodeValue(value.Index(i), e.column)
+		node, err := e.encodeValue(ctx, value.Index(i), e.column)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to encode value for slice")
 		}
@@ -296,10 +370,10 @@ func (e *Encoder) encodeSlice(value reflect.Value) (ast.Node, error) {
 	return sequence, nil
 }
 
-func (e *Encoder) encodeMapItem(item MapItem, column int) (*ast.MappingValueNode, error) {
+func (e *Encoder) encodeMapItem(ctx context.Context, item MapItem, column int) (*ast.MappingValueNode, error) {
 	k := reflect.ValueOf(item.Key)
 	v := reflect.ValueOf(item.Value)
-	value, err := e.encodeValue(v, column)
+	value, err := e.encodeValue(ctx, v, column)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to encode MapItem")
 	}
@@ -313,10 +387,10 @@ func (e *Encoder) encodeMapItem(item MapItem, column int) (*ast.MappingValueNode
 	), nil
 }
 
-func (e *Encoder) encodeMapSlice(value MapSlice, column int) (ast.Node, error) {
+func (e *Encoder) encodeMapSlice(ctx context.Context, value MapSlice, column int) (ast.Node, error) {
 	node := ast.Mapping(token.New("", "", e.pos(column)), e.isFlowStyle)
 	for _, item := range value {
-		value, err := e.encodeMapItem(item, column)
+		value, err := e.encodeMapItem(ctx, item, column)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to encode MapItem for MapSlice")
 		}
@@ -325,7 +399,7 @@ func (e *Encoder) encodeMapSlice(value MapSlice, column int) (ast.Node, error) {
 	return node, nil
 }
 
-func (e *Encoder) encodeMap(value reflect.Value, column int) ast.Node {
+func (e *Encoder) encodeMap(ctx context.Context, value reflect.Value, column int) ast.Node {
 	node := ast.Mapping(token.New("", "", e.pos(column)), e.isFlowStyle)
 	keys := []string{}
 	for _, k := range value.MapKeys() {
@@ -335,7 +409,7 @@ func (e *Encoder) encodeMap(value reflect.Value, column int) ast.Node {
 	for _, key := range keys {
 		k := reflect.ValueOf(key)
 		v := value.MapIndex(k)
-		value, err := e.encodeValue(v, column)
+		value, err := e.encodeValue(ctx, v, column)
 		if err != nil {
 			return nil
 		}
@@ -424,7 +498,7 @@ func (e *Encoder) encodeAnchor(anchorName string, value ast.Node, fieldValue ref
 	return anchorNode, nil
 }
 
-func (e *Encoder) encodeStruct(value reflect.Value, column int) (ast.Node, error) {
+func (e *Encoder) encodeStruct(ctx context.Context, value reflect.Value, column int) (ast.Node, error) {
 	node := ast.Mapping(token.New("", "", e.pos(column)), e.isFlowStyle)
 	structType := value.Type()
 	structFieldMap, err := structFieldMap(structType)
@@ -444,7 +518,7 @@ func (e *Encoder) encodeStruct(value reflect.Value, column int) (ast.Node, error
 			// omit encoding
 			continue
 		}
-		value, err := e.encodeValue(fieldValue, column)
+		value, err := e.encodeValue(ctx, fieldValue, column)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to encode value")
 		}

--- a/encode_test.go
+++ b/encode_test.go
@@ -2,6 +2,7 @@ package yaml_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -930,6 +931,30 @@ func Test_Marshaler(t *testing.T) {
 	}
 
 	t.Logf("%s", buf)
+}
+
+type marshalWithContext struct{}
+
+func (c *marshalWithContext) MarshalYAML(ctx context.Context) ([]byte, error) {
+	v, ok := ctx.Value("k").(int)
+	if !ok {
+		return nil, fmt.Errorf("cannot get valid context")
+	}
+	if v != 1 {
+		return nil, fmt.Errorf("cannot get valid context")
+	}
+	return []byte("1"), nil
+}
+
+func Test_MarshalerWithContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "k", 1)
+	bytes, err := yaml.MarshalWithContext(ctx, &marshalWithContext{})
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	if string(bytes) != "1\n" {
+		t.Fatalf("failed marshal: %q", string(bytes))
+	}
 }
 
 type SlowMarshaler struct {


### PR DESCRIPTION
Add new APIs for passing `context.Context` to `MarshalYAML` and `UnmarshalYAML` .

- `yaml.MarshalWithContext(ctx context.Context, v interface{}, opts ...EncodeOption) ([]byte, error)`
- `yaml.UnmarshalWithContext(ctx context.Context, b []byte, v interface{}, opts ...DecodeOption) error`

