### PR TITLE
Fix to give back error when path not found

### DIFF
--- a/path.go
+++ b/path.go
@@ -214,7 +214,7 @@ func (p *Path) FilterFile(f *ast.File) (ast.Node, error) {
 			return node, nil
 		}
 	}
-	return nil, nil
+	return nil, fmt.Errorf("path ( %s ) not found", p.node)
 }
 
 // FilterNode filter from node by YAMLPath.

--- a/path.go
+++ b/path.go
@@ -17,6 +17,7 @@ var (
 	ErrInvalidQuery      = xerrors.New("invalid query")
 	ErrInvalidPath       = xerrors.New("invalid path instance")
 	ErrInvalidPathString = xerrors.New("invalid path string")
+	ErrNotFoundNode      = xerrors.New("node not found")
 )
 
 // PathString create Path from string
@@ -214,7 +215,7 @@ func (p *Path) FilterFile(f *ast.File) (ast.Node, error) {
 			return node, nil
 		}
 	}
-	return nil, fmt.Errorf("path ( %s ) not found", p.node)
+	return nil, errors.Wrapf(ErrNotFoundNode, "failed to find path ( %s )", p.node)
 }
 
 // FilterNode filter from node by YAMLPath.


### PR DESCRIPTION
Fixes https://github.com/goccy/go-yaml/issues/193

This is happening because `Path.Read()` assumes it's going to have a non-nil Node if no error returned. But it could give back a nil Node even if no error was given.

I little poked around the codebase and most of the callers of `Path.FilterFile()` assume the same does.

It would be great if you could give me any feedback.