### PR TITLE
Allow -0 as an octet integer value

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -243,7 +243,7 @@ func Integer(tk *token.Token) Node {
 		negativePrefix := ""
 		if value[0] == '-' {
 			skipCharacterNum++
-			if value[2] == 'o' {
+			if len(value) > 2 && value[2] == 'o' {
 				skipCharacterNum++
 			}
 			negativePrefix = "-"


### PR DESCRIPTION
Currently, giving `-0` causes panic. This PR is a tiny fix for that.
```go
package main

import (
	"bytes"
	"fmt"
	"log"

	goyaml "github.com/goccy/go-yaml"
)

func main() {
	yml := []byte(`foo: -0`)
	path := "$.foo"
	p, err := goyaml.PathString(path)
	if err != nil {
		log.Fatal(err)
	}

	var value interface{}
	if err := p.Read(bytes.NewReader(yml), &value); err != nil {
		log.Fatal(err)
	}
}
```