### PR TITLE
Fixing Issue 185, incorrect column annotation when single or double q…

### DIFF
--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -256,7 +256,7 @@ func TestTokenValueAndLineColumnPosition(t *testing.T) {
 			}
 			for i, tok := range got {
 				if !tokenMatches(tok, expected[i]) {
-					t.Errorf("Tokenize(%s) expected line:%d column:%d value:%s , got:%+v", tc.src, tok.Position.Line, tok.Position.Column, tok.Value, expected[i])
+					t.Errorf("Tokenize(%s) expected:%+v got line:%d column:%d value:%s", tc.src, expected[i], tok.Position.Line, tok.Position.Column, tok.Value)
 				}
 			}
 		})

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -195,8 +195,9 @@ func (s *Scanner) breakLiteral(ctx *Context) {
 
 func (s *Scanner) scanSingleQuote(ctx *Context) (tk *token.Token, pos int) {
 	ctx.addOriginBuf('\'')
+	srcpos := s.pos()
 	startIndex := ctx.idx + 1
-	ctx.progress(1)
+	s.progressColumn(ctx, 1)
 	src := ctx.src
 	size := len(src)
 	value := []rune{}
@@ -223,7 +224,7 @@ func (s *Scanner) scanSingleQuote(ctx *Context) (tk *token.Token, pos int) {
 			idx++
 			continue
 		}
-		tk = token.SingleQuote(string(value), string(ctx.obuf), s.pos())
+		tk = token.SingleQuote(string(value), string(ctx.obuf), srcpos)
 		pos = idx - startIndex + 1
 		return
 	}
@@ -250,8 +251,9 @@ func hexRunesToInt(b []rune) int {
 
 func (s *Scanner) scanDoubleQuote(ctx *Context) (tk *token.Token, pos int) {
 	ctx.addOriginBuf('"')
+	srcpos := s.pos()
 	startIndex := ctx.idx + 1
-	ctx.progress(1)
+	s.progressColumn(ctx, 1)
 	src := ctx.src
 	size := len(src)
 	value := []rune{}
@@ -363,7 +365,7 @@ func (s *Scanner) scanDoubleQuote(ctx *Context) (tk *token.Token, pos int) {
 			isFirstLineChar = false
 			continue
 		}
-		tk = token.DoubleQuote(string(value), string(ctx.obuf), s.pos())
+		tk = token.DoubleQuote(string(value), string(ctx.obuf), srcpos)
 		pos = idx - startIndex + 1
 		return
 	}


### PR DESCRIPTION
…uotes are used

When single or double quotes are in scanner.go:

case '\'', '"':
	if !ctx.existsBuffer() {
	token, progress := s.scanQuote(ctx, c)
	ctx.addToken(token)
	s.progressColumn(ctx, progress)
...

progress does not account for the initial position advancement form the start quote in the scanQuote() call. i.e. a token with the 3 character:

"1"

only progresses the column 2 positions (scanQuote() returns progress=2), instead of 3, causing a loss in synchronization.