### PR TITLE
Fixing Issue 186, scanner should account for newline characters when …

### DIFF
--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -68,7 +68,7 @@ type testToken struct {
 	value  string
 }
 
-func TestTokenValueAndLineColumnPosition(t *testing.T) {
+func TestSingleLineToken_ValueLineColumnPosition(t *testing.T) {
 	tests := []struct {
 		name   string
 		src    string
@@ -268,4 +268,200 @@ func tokenMatches(t *token.Token, e testToken) bool {
 		t.Value == e.value &&
 		t.Position.Line == e.line &&
 		t.Position.Column == e.column
+}
+
+func TestMultiLineToken_ValueLineColumnPosition(t *testing.T) {
+	tests := []struct {
+		name   string
+		src    string
+		expect []testToken
+	}{
+		{
+			name: "double quote",
+			src: `one: "1 2 3 4 5"
+two: "1 2
+3 4
+5"
+three: "1 2 3 4
+5"`,
+			expect: []testToken{
+				{
+					line:   1,
+					column: 1,
+					value:  "one",
+				},
+				{
+					line:   1,
+					column: 4,
+					value:  ":",
+				},
+				{
+					line:   1,
+					column: 6,
+					value:  "1 2 3 4 5",
+				},
+				{
+					line:   2,
+					column: 1,
+					value:  "two",
+				},
+				{
+					line:   2,
+					column: 4,
+					value:  ":",
+				},
+				{
+					line:   2,
+					column: 6,
+					value:  "1 2 3 4 5",
+				},
+				{
+					line:   5,
+					column: 1,
+					value:  "three",
+				},
+				{
+					line:   5,
+					column: 6,
+					value:  ":",
+				},
+				{
+					line:   5,
+					column: 8,
+					value:  "1 2 3 4 5",
+				},
+			},
+		},
+		{
+			name: "single quote in an array",
+			src: `arr: ['1', 'and
+two']
+last: 'hello'`,
+			expect: []testToken{
+				{
+					line:   1,
+					column: 1,
+					value:  "arr",
+				},
+				{
+					line:   1,
+					column: 4,
+					value:  ":",
+				},
+				{
+					line:   1,
+					column: 6,
+					value:  "[",
+				},
+				{
+					line:   1,
+					column: 7,
+					value:  "1",
+				},
+				{
+					line:   1,
+					column: 10,
+					value:  ",",
+				},
+				{
+					line:   1,
+					column: 12,
+					value:  "and two",
+				},
+				{
+					line:   2,
+					column: 5,
+					value:  "]",
+				},
+				{
+					line:   3,
+					column: 1,
+					value:  "last",
+				},
+				{
+					line:   3,
+					column: 5,
+					value:  ":",
+				},
+				{
+					line:   3,
+					column: 7,
+					value:  "hello",
+				},
+			},
+		},
+		{
+			name: "single quote and double quote",
+			src: `foo: "test
+
+
+
+
+bar"
+foo2: 'bar2'`,
+			expect: []testToken{
+				{
+					line:   1,
+					column: 1,
+					value:  "foo",
+				},
+				{
+					line:   1,
+					column: 4,
+					value:  ":",
+				},
+				{
+					line:   1,
+					column: 6,
+					value:  "test     bar",
+				},
+				{
+					line:   7,
+					column: 1,
+					value:  "foo2",
+				},
+				{
+					line:   7,
+					column: 5,
+					value:  ":",
+				},
+				{
+					line:   7,
+					column: 7,
+					value:  "bar2",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := lexer.Tokenize(tc.src)
+			sort.Slice(got, func(i, j int) bool {
+				// sort by line, then column
+				if got[i].Position.Line < got[j].Position.Line {
+					return true
+				} else if got[i].Position.Line == got[j].Position.Line {
+					return got[i].Position.Column < got[j].Position.Column
+				}
+				return false
+			})
+			sort.Slice(tc.expect, func(i, j int) bool {
+				if tc.expect[i].line < tc.expect[j].line {
+					return true
+				} else if tc.expect[i].line == tc.expect[j].line {
+					return tc.expect[i].column < tc.expect[j].column
+				}
+				return false
+			})
+			if len(got) != len(tc.expect) {
+				t.Errorf("Tokenize() token count mismatch, expected:%d got:%d", len(tc.expect), len(got))
+			}
+			for i, tok := range got {
+				if !tokenMatches(tok, tc.expect[i]) {
+					t.Errorf("Tokenize() expected:%+v got line:%d column:%d value:%s", tc.expect[i], tok.Position.Line, tok.Position.Column, tok.Value)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
…processing multi-line text. Without this source annotations line/column number (for this and all subsequent tokens) is inconsistent with plain text editors. e.g. https://github.com/goccy/go-yaml/issues/186. This addresses the issue specifically for single and double quote text only.

Note: 

1.) We would have preferred to avoid introducing an additional state in the loop (isNewLine), but this requires placing the column marker to an invalid position (0) and believe it is safer not to do so. This is done to avoid potential bugs in the future if the loop exits before the column marker can be brought back in-bounds. 

2.) We debated internally whether the slice sorting in the tests should be done through a helper function or not. We didn't feel a convenience function improved code readability to merit consolidation of the logic. If you disagree, lmk. We add the sort to be token order agnostic in our tests.