### PR TITLE
Add error for unterminated flow mapping node

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -21,7 +21,7 @@ func (p *parser) parseMapping(ctx *context) (ast.Node, error) {
 		tk := ctx.currentToken()
 		if tk.Type == token.MappingEndType {
 			node.End = tk
-			break
+			return node, nil
 		} else if tk.Type == token.CollectEntryType {
 			ctx.progress(1)
 			continue
@@ -38,7 +38,7 @@ func (p *parser) parseMapping(ctx *context) (ast.Node, error) {
 		node.Values = append(node.Values, mvnode)
 		ctx.progress(1)
 	}
-	return node, nil
+	return nil, errors.ErrSyntax("unterminated flow mapping", node.GetToken())
 }
 
 func (p *parser) parseSequence(ctx *context) (ast.Node, error) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -635,6 +635,14 @@ a
         ^
 `,
 		},
+		{
+			`{ "key": "value" `,
+			`
+[1:1] unterminated flow mapping
+>  1 | { "key": "value"
+       ^
+`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.source, func(t *testing.T) {


### PR DESCRIPTION
Hello @goccy, I found your yaml parser as an alternative to go-yaml, and it seems to handle several cases that go-yaml/yaml doesn't: not just anchors and aliases, but also repeated flow documents (`{ ... }{ ... }`) and tabs in flow documents, which I think would allow us to replace our use of `encoding/json` with it.

I created this pull request to add one piece of error handling, for unterminated flow documents—please let me know what you think, or if there's more I can or should do to improve it. Also please let me know if other pull requests would be welcome. There are two other changes I'd be interested in making, if you're open to them:

- Error on unterminated strings (`"abc...<EOF>`)
- Acceptance tests for repeated flow documents and tabs in flow documents (an important use case for us)

I'd be happy to get in touch if you want to discuss these further.

Thanks for creating such a great library!