### PR TITLE
Handle missing required field validation

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1061,6 +1061,10 @@ func (d *Decoder) decodeStruct(ctx context.Context, dst reflect.Value, src ast.N
 					if exists {
 						// TODO: to make FieldError message cutomizable
 						return errors.ErrSyntax(fmt.Sprintf("%s", err), node.GetToken())
+					} else if t := src.GetToken(); t != nil && t.Prev != nil && t.Prev.Prev != nil {
+						// A missing required field will not be in the keyToNodeMap
+						// the error needs to be associated with the parent of the source node
+						return errors.ErrSyntax(fmt.Sprintf("%s", err), t.Prev.Prev)
 					}
 				}
 			}

--- a/validate_test.go
+++ b/validate_test.go
@@ -45,7 +45,13 @@ name: john
 age: 10
 addr:
   number: seven`,
-			ExpectedErr: "",
+			ExpectedErr: `[4:5] Key: 'State' Error:Field validation for 'State' failed on the 'required' tag
+   1 | ---
+   2 | name: john
+   3 | age: 10
+>  4 | addr:
+           ^
+   5 |   number: seven`,
 			Instance: &struct {
 				Name string `yaml:"name" validate:"required"`
 				Age  int    `yaml:"age" validate:"gte=0,lt=120"`

--- a/validate_test.go
+++ b/validate_test.go
@@ -39,6 +39,24 @@ func TestStructValidator(t *testing.T) {
 			}{},
 		},
 		{
+			TestName: "Test Missing Required Field",
+			YAMLContent: `---
+- name: john
+  age: 20
+- age: 10`,
+			ExpectedErr: `[4:1] Key: 'Name' Error:Field validation for 'Name' failed on the 'required' tag
+   1 | ---
+   2 | - name: john
+   3 |   age: 20
+>  4 | - age: 10
+       ^
+`,
+			Instance: &[]struct {
+				Name string `yaml:"name" validate:"required"`
+				Age  int    `yaml:"age" validate:"gte=0,lt=120"`
+			}{},
+		},
+		{
 			TestName: "Test Nested Validation Missing Internal Required",
 			YAMLContent: `---
 name: john


### PR DESCRIPTION
The current implementation ignores field errors when a required struct field is missing in the yaml.  This change will enable that error to be associated with the token of the parent of the node being validated.  Please consider accepting this small change which might be useful for others.