### PR TITLE
Nicely format unexpected node type errors

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -110,6 +110,54 @@ func (t NodeType) String() string {
 	return ""
 }
 
+// String node type identifier to YAML Structure name
+// based on https://yaml.org/spec/1.2/spec.html
+func (t NodeType) YAMLName() string {
+	switch t {
+	case UnknownNodeType:
+		return "unknown"
+	case DocumentType:
+		return "document"
+	case NullType:
+		return "null"
+	case BoolType:
+		return "boolean"
+	case IntegerType:
+		return "int"
+	case FloatType:
+		return "float"
+	case InfinityType:
+		return "inf"
+	case NanType:
+		return "nan"
+	case StringType:
+		return "string"
+	case MergeKeyType:
+		return "merge key"
+	case LiteralType:
+		return "scalar"
+	case MappingType:
+		return "mapping"
+	case MappingKeyType:
+		return "key"
+	case MappingValueType:
+		return "value"
+	case SequenceType:
+		return "sequence"
+	case AnchorType:
+		return "anchor"
+	case AliasType:
+		return "alias"
+	case DirectiveType:
+		return "directive"
+	case TagType:
+		return "tag"
+	case CommentType:
+		return "comment"
+	}
+	return ""
+}
+
 // Node type of node
 type Node interface {
 	io.Reader

--- a/decode.go
+++ b/decode.go
@@ -281,7 +281,7 @@ func (d *Decoder) getMapNode(node ast.Node) (ast.MapNode, error) {
 		if ok {
 			return mapNode, nil
 		}
-		return nil, xerrors.Errorf("%s node found where MapNode is expected", anchor.Value.Type())
+		return nil, errUnexpectedNodeType(anchor.Value.Type(), ast.MappingType, node.GetToken())
 	}
 	if alias, ok := node.(*ast.AliasNode); ok {
 		aliasName := alias.Value.GetToken().Value
@@ -293,11 +293,11 @@ func (d *Decoder) getMapNode(node ast.Node) (ast.MapNode, error) {
 		if ok {
 			return mapNode, nil
 		}
-		return nil, xerrors.Errorf("%s node found where MapNode is expected", node.Type())
+		return nil, errUnexpectedNodeType(node.Type(), ast.MappingType, node.GetToken())
 	}
 	mapNode, ok := node.(ast.MapNode)
 	if !ok {
-		return nil, xerrors.Errorf("%s node found where MapNode is expected", node.Type())
+		return nil, errUnexpectedNodeType(node.Type(), ast.MappingType, node.GetToken())
 	}
 	return mapNode, nil
 }
@@ -311,7 +311,8 @@ func (d *Decoder) getArrayNode(node ast.Node) (ast.ArrayNode, error) {
 		if ok {
 			return arrayNode, nil
 		}
-		return nil, xerrors.Errorf("%s node found where ArrayNode is expected", anchor.Value.Type())
+
+		return nil, errUnexpectedNodeType(anchor.Value.Type(), ast.SequenceType, node.GetToken())
 	}
 	if alias, ok := node.(*ast.AliasNode); ok {
 		aliasName := alias.Value.GetToken().Value
@@ -323,11 +324,11 @@ func (d *Decoder) getArrayNode(node ast.Node) (ast.ArrayNode, error) {
 		if ok {
 			return arrayNode, nil
 		}
-		return nil, xerrors.Errorf("%s node found where ArrayNode is expected", node.Type())
+		return nil, errUnexpectedNodeType(node.Type(), ast.SequenceType, node.GetToken())
 	}
 	arrayNode, ok := node.(ast.ArrayNode)
 	if !ok {
-		return nil, xerrors.Errorf("%s node found where ArrayNode is expected", node.Type())
+		return nil, errUnexpectedNodeType(node.Type(), ast.SequenceType, node.GetToken())
 	}
 	return arrayNode, nil
 }
@@ -405,6 +406,10 @@ func (e *unknownFieldError) Error() string {
 
 func errUnknownField(msg string, tk *token.Token) *unknownFieldError {
 	return &unknownFieldError{err: errors.ErrSyntax(msg, tk)}
+}
+
+func errUnexpectedNodeType(actual, expected ast.NodeType, tk *token.Token) error {
+	return errors.ErrSyntax(fmt.Sprintf("%s node found where %s is expected", actual, expected), tk)
 }
 
 type duplicateKeyError struct {

--- a/decode.go
+++ b/decode.go
@@ -409,7 +409,7 @@ func errUnknownField(msg string, tk *token.Token) *unknownFieldError {
 }
 
 func errUnexpectedNodeType(actual, expected ast.NodeType, tk *token.Token) error {
-	return errors.ErrSyntax(fmt.Sprintf("%s node found where %s is expected", actual, expected), tk)
+	return errors.ErrSyntax(fmt.Sprintf("%s was used where %s is expected", actual.YAMLName(), expected.YAMLName()), tk)
 }
 
 type duplicateKeyError struct {

--- a/validate_test.go
+++ b/validate_test.go
@@ -105,6 +105,36 @@ addr:
 				} `yaml:"addr" validate:"required"`
 			}{},
 		},
+		{
+			TestName: "Test Validation with wrong field type",
+			YAMLContent: `---
+name: myDocument
+roles:
+  name: myRole
+  permissions:
+	- hello
+	- how
+	- are
+	- you
+	`,
+			ExpectedErr: `[4:7] Mapping node found where Sequence is expected
+   1 | ---
+   2 | name: myDocument
+   3 | roles:
+>  4 |   name: myRole
+             ^
+   5 |   permissions:
+   6 | 	- hello
+   7 | 	- how
+   8 | `,
+			Instance: &struct {
+				Name  string `yaml:"name"`
+				Roles []struct {
+					Name        string   `yaml:"name"`
+					Permissions []string `yaml:"permissions"`
+				} `yaml:"roles"`
+			}{},
+		},
 	}
 
 	for _, tc := range cases {

--- a/validate_test.go
+++ b/validate_test.go
@@ -117,7 +117,7 @@ roles:
 	- are
 	- you
 	`,
-			ExpectedErr: `[4:7] Mapping node found where Sequence is expected
+			ExpectedErr: `[4:7] mapping was used where sequence is expected
    1 | ---
    2 | name: myDocument
    3 | roles:


### PR DESCRIPTION
This fixes #182 by emitting a ErrSyntax error when the actual field type doesn't match the expected field type.  I've encountered a similar issue in another project and this change would enable my tool to provide cleaner error message as well.