### PR TITLE
Rename MarshalWithContext and UnmarshalWithContext

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1686,11 +1686,11 @@ func TestDecoder_UseJSONUnmarshaler(t *testing.T) {
 	}
 }
 
-type unmarshalWithContext struct {
+type unmarshalContext struct {
 	v int
 }
 
-func (c *unmarshalWithContext) UnmarshalYAML(ctx context.Context, b []byte) error {
+func (c *unmarshalContext) UnmarshalYAML(ctx context.Context, b []byte) error {
 	v, ok := ctx.Value("k").(int)
 	if !ok {
 		return fmt.Errorf("cannot get valid context")
@@ -1705,10 +1705,10 @@ func (c *unmarshalWithContext) UnmarshalYAML(ctx context.Context, b []byte) erro
 	return nil
 }
 
-func Test_UnmarshalerWithContext(t *testing.T) {
+func Test_UnmarshalerContext(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "k", 1)
-	var v unmarshalWithContext
-	if err := yaml.UnmarshalWithContext(ctx, []byte(`1`), &v); err != nil {
+	var v unmarshalContext
+	if err := yaml.UnmarshalContext(ctx, []byte(`1`), &v); err != nil {
 		t.Fatalf("%+v", err)
 	}
 	if v.v != 1 {

--- a/encode_test.go
+++ b/encode_test.go
@@ -1173,9 +1173,9 @@ func Test_Marshaler(t *testing.T) {
 	t.Logf("%s", buf)
 }
 
-type marshalWithContext struct{}
+type marshalContext struct{}
 
-func (c *marshalWithContext) MarshalYAML(ctx context.Context) ([]byte, error) {
+func (c *marshalContext) MarshalYAML(ctx context.Context) ([]byte, error) {
 	v, ok := ctx.Value("k").(int)
 	if !ok {
 		return nil, fmt.Errorf("cannot get valid context")
@@ -1186,9 +1186,9 @@ func (c *marshalWithContext) MarshalYAML(ctx context.Context) ([]byte, error) {
 	return []byte("1"), nil
 }
 
-func Test_MarshalerWithContext(t *testing.T) {
+func Test_MarshalerContext(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "k", 1)
-	bytes, err := yaml.MarshalWithContext(ctx, &marshalWithContext{})
+	bytes, err := yaml.MarshalContext(ctx, &marshalContext{})
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/yaml.go
+++ b/yaml.go
@@ -130,11 +130,11 @@ func Marshal(v interface{}) ([]byte, error) {
 
 // MarshalWithOptions serializes the value provided into a YAML document with EncodeOptions.
 func MarshalWithOptions(v interface{}, opts ...EncodeOption) ([]byte, error) {
-	return MarshalWithContext(context.Background(), v, opts...)
+	return MarshalContext(context.Background(), v, opts...)
 }
 
-// MarshalWithContext serializes the value provided into a YAML document with context.Context and EncodeOptions.
-func MarshalWithContext(ctx context.Context, v interface{}, opts ...EncodeOption) ([]byte, error) {
+// MarshalContext serializes the value provided into a YAML document with context.Context and EncodeOptions.
+func MarshalContext(ctx context.Context, v interface{}, opts ...EncodeOption) ([]byte, error) {
 	var buf bytes.Buffer
 	if err := NewEncoder(&buf, opts...).EncodeContext(ctx, v); err != nil {
 		return nil, errors.Wrapf(err, "failed to marshal")
@@ -182,11 +182,11 @@ func Unmarshal(data []byte, v interface{}) error {
 // UnmarshalWithOptions decodes with DecodeOptions the first document found within the in byte slice
 // and assigns decoded values into the out value.
 func UnmarshalWithOptions(data []byte, v interface{}, opts ...DecodeOption) error {
-	return UnmarshalWithContext(context.Background(), data, v, opts...)
+	return UnmarshalContext(context.Background(), data, v, opts...)
 }
 
-// UnmarshalWithContext decodes with context.Context and DecodeOptions.
-func UnmarshalWithContext(ctx context.Context, data []byte, v interface{}, opts ...DecodeOption) error {
+// UnmarshalContext decodes with context.Context and DecodeOptions.
+func UnmarshalContext(ctx context.Context, data []byte, v interface{}, opts ...DecodeOption) error {
 	dec := NewDecoder(bytes.NewBuffer(data), opts...)
 	if err := dec.DecodeContext(ctx, v); err != nil {
 		if err == io.EOF {


### PR DESCRIPTION
### **This changes is breaking change** 

Rename `MarshalWithContext` to `MarshalContext` and `UnmarshalWithContext` to `UnmarshalContext`
