### PR TITLE
Add yaml.NodeToValue(ast.Node, interface{}, ...DecodeOption) error

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1489,3 +1489,25 @@ func (d *Decoder) DecodeContext(ctx context.Context, v interface{}) error {
 	}
 	return nil
 }
+
+// DecodeFromNode decodes node into the value pointed to by v.
+func (d *Decoder) DecodeFromNode(node ast.Node, v interface{}) error {
+	return d.DecodeFromNodeContext(context.Background(), node, v)
+}
+
+// DecodeFromNodeContext decodes node into the value pointed to by v with context.Context.
+func (d *Decoder) DecodeFromNodeContext(ctx context.Context, node ast.Node, v interface{}) error {
+	rv := reflect.ValueOf(v)
+	if rv.Type().Kind() != reflect.Ptr {
+		return errors.ErrDecodeRequiredPointerType
+	}
+	if !d.isInitialized() {
+		if err := d.decodeInit(); err != nil {
+			return errors.Wrapf(err, "failed to decodInit")
+		}
+	}
+	if err := d.decodeValue(ctx, rv.Elem(), node); err != nil {
+		return errors.Wrapf(err, "failed to decode value")
+	}
+	return nil
+}

--- a/yaml.go
+++ b/yaml.go
@@ -197,6 +197,15 @@ func UnmarshalWithContext(ctx context.Context, data []byte, v interface{}, opts 
 	return nil
 }
 
+// NodeToValue converts node to the value pointed to by v.
+func NodeToValue(node ast.Node, v interface{}, opts ...DecodeOption) error {
+	var buf bytes.Buffer
+	if err := NewDecoder(&buf, opts...).DecodeFromNode(node, v); err != nil {
+		return errors.Wrapf(err, "failed to convert node to value")
+	}
+	return nil
+}
+
 // FormatError is a utility function that takes advantage of the metadata
 // stored in the errors returned by this package's parser.
 //


### PR DESCRIPTION
`go-yaml` can convert a value to an AST node by `ValueToNode`. This PR adds the opposite function `NodeToValue`.