### PR TITLE
Support WithComment option

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -82,10 +82,8 @@ func (e *Encoder) EncodeContext(ctx context.Context, v interface{}) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to encode to node")
 	}
-	if e.commentMap != nil {
-		if err := e.setCommentByCommentMap(node); err != nil {
-			return errors.Wrapf(err, "failed to set comment by comment map")
-		}
+	if err := e.setCommentByCommentMap(node); err != nil {
+		return errors.Wrapf(err, "failed to set comment by comment map")
 	}
 	var p printer.Printer
 	e.writer.Write(p.PrintNode(node))
@@ -112,6 +110,9 @@ func (e *Encoder) EncodeToNodeContext(ctx context.Context, v interface{}) (ast.N
 }
 
 func (e *Encoder) setCommentByCommentMap(node ast.Node) error {
+	if e.commentMap == nil {
+		return nil
+	}
 	for path, comment := range e.commentMap {
 		n, err := path.FilterNode(node)
 		if err != nil {

--- a/encode.go
+++ b/encode.go
@@ -37,6 +37,7 @@ type Encoder struct {
 	anchorCallback             func(*ast.AnchorNode, interface{}) error
 	anchorPtrToNameMap         map[uintptr]string
 	useLiteralStyleIfMultiline bool
+	commentMap                 map[*Path]*Comment
 
 	line        int
 	column      int
@@ -81,6 +82,11 @@ func (e *Encoder) EncodeContext(ctx context.Context, v interface{}) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to encode to node")
 	}
+	if e.commentMap != nil {
+		if err := e.setCommentByCommentMap(node); err != nil {
+			return errors.Wrapf(err, "failed to set comment by comment map")
+		}
+	}
 	var p printer.Printer
 	e.writer.Write(p.PrintNode(node))
 	return nil
@@ -103,6 +109,46 @@ func (e *Encoder) EncodeToNodeContext(ctx context.Context, v interface{}) (ast.N
 		return nil, errors.Wrapf(err, "failed to encode value")
 	}
 	return node, nil
+}
+
+func (e *Encoder) setCommentByCommentMap(node ast.Node) error {
+	for path, comment := range e.commentMap {
+		n, err := path.FilterNode(node)
+		if err != nil {
+			return errors.Wrapf(err, "failed to filter node")
+		}
+		comments := []*token.Token{}
+		for _, text := range comment.Texts {
+			comments = append(comments, token.New(text, text, nil))
+		}
+		commentGroup := ast.CommentGroup(comments)
+		switch comment.Position {
+		case CommentLinePosition:
+			if err := n.SetComment(commentGroup); err != nil {
+				return errors.Wrapf(err, "failed to set comment")
+			}
+		case CommentHeadPosition:
+			parent := ast.Parent(node, n)
+			if parent == nil {
+				return ErrUnsupportedHeadPositionType(node)
+			}
+			switch node := parent.(type) {
+			case *ast.MappingValueNode:
+				if err := node.SetComment(commentGroup); err != nil {
+					return errors.Wrapf(err, "failed to set comment")
+				}
+			case *ast.MappingNode:
+				if err := node.SetComment(commentGroup); err != nil {
+					return errors.Wrapf(err, "failed to set comment")
+				}
+			default:
+				return ErrUnsupportedHeadPositionType(node)
+			}
+		default:
+			return ErrUnknownCommentPositionType
+		}
+	}
+	return nil
 }
 
 func (e *Encoder) encodeDocument(doc []byte) (ast.Node, error) {

--- a/error.go
+++ b/error.go
@@ -6,11 +6,16 @@ import (
 )
 
 var (
-	ErrInvalidQuery      = xerrors.New("invalid query")
-	ErrInvalidPath       = xerrors.New("invalid path instance")
-	ErrInvalidPathString = xerrors.New("invalid path string")
-	ErrNotFoundNode      = xerrors.New("node not found")
+	ErrInvalidQuery               = xerrors.New("invalid query")
+	ErrInvalidPath                = xerrors.New("invalid path instance")
+	ErrInvalidPathString          = xerrors.New("invalid path string")
+	ErrNotFoundNode               = xerrors.New("node not found")
+	ErrUnknownCommentPositionType = xerrors.New("unknown comment position type")
 )
+
+func ErrUnsupportedHeadPositionType(node ast.Node) error {
+	return xerrors.Errorf("unsupported comment head position for %s", node.Type())
+}
 
 // IsInvalidQueryError whether err is ErrInvalidQuery or not.
 func IsInvalidQueryError(err error) bool {

--- a/option.go
+++ b/option.go
@@ -156,3 +156,63 @@ func UseJSONMarshaler() EncodeOption {
 		return nil
 	}
 }
+
+// CommentPosition type of the position for comment.
+type CommentPosition int
+
+const (
+	CommentLinePosition CommentPosition = iota
+	CommentHeadPosition
+)
+
+func (p CommentPosition) String() string {
+	switch p {
+	case CommentLinePosition:
+		return "Line"
+	case CommentHeadPosition:
+		return "Head"
+	default:
+		return ""
+	}
+}
+
+// LineComment create a one-line comment for CommentMap.
+func LineComment(text string) *Comment {
+	return &Comment{
+		Texts:    []string{text},
+		Position: CommentLinePosition,
+	}
+}
+
+// HeadComment create a multiline comment for CommentMap.
+func HeadComment(texts ...string) *Comment {
+	return &Comment{
+		Texts:    texts,
+		Position: CommentHeadPosition,
+	}
+}
+
+// Comment raw data for comment.
+type Comment struct {
+	Texts    []string
+	Position CommentPosition
+}
+
+// CommentMap map of the position of the comment and the comment information.
+type CommentMap map[string]*Comment
+
+// WithComment add a comment using the location and text information given in the CommentMap.
+func WithComment(cm CommentMap) EncodeOption {
+	return func(e *Encoder) error {
+		commentMap := map[*Path]*Comment{}
+		for k, v := range cm {
+			path, err := PathString(k)
+			if err != nil {
+				return err
+			}
+			commentMap[path] = v
+		}
+		e.commentMap = commentMap
+		return nil
+	}
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -382,3 +382,87 @@ a: 1
 		t.Fatalf("failed to convert json to yaml: expected [%q] but got [%q]", expected, actual)
 	}
 }
+
+func Test_CommentMapOption(t *testing.T) {
+	v := struct {
+		Foo string                 `yaml:"foo"`
+		Bar map[string]interface{} `yaml:"bar"`
+		Baz struct {
+			X int `yaml:"x"`
+		} `yaml:"baz"`
+	}{
+		Foo: "aaa",
+		Bar: map[string]interface{}{"bbb": "ccc"},
+		Baz: struct {
+			X int `yaml:"x"`
+		}{X: 10},
+	}
+	t.Run("line comment", func(t *testing.T) {
+		b, err := yaml.MarshalWithOptions(v, yaml.WithComment(
+			yaml.CommentMap{
+				"$.foo":     yaml.LineComment("foo comment"),
+				"$.bar":     yaml.LineComment("bar comment"),
+				"$.bar.bbb": yaml.LineComment("bbb comment"),
+				"$.baz.x":   yaml.LineComment("x comment"),
+			},
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := `
+foo: aaa #foo comment
+bar: #bar comment
+  bbb: ccc #bbb comment
+baz:
+  x: 10 #x comment
+`
+		actual := "\n" + string(b)
+		if expected != actual {
+			t.Fatalf("expected:%s but got %s", expected, actual)
+		}
+	})
+	t.Run("head comment", func(t *testing.T) {
+		b, err := yaml.MarshalWithOptions(v, yaml.WithComment(
+			yaml.CommentMap{
+				"$.foo": yaml.HeadComment(
+					"foo comment",
+					"foo comment2",
+				),
+				"$.bar": yaml.HeadComment(
+					"bar comment",
+					"bar comment2",
+				),
+				"$.bar.bbb": yaml.HeadComment(
+					"bbb comment",
+					"bbb comment2",
+				),
+				"$.baz.x": yaml.HeadComment(
+					"x comment",
+					"x comment2",
+				),
+			},
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := `
+#foo comment
+#foo comment2
+foo: aaa
+#bar comment
+#bar comment2
+bar:
+  #bbb comment
+  #bbb comment2
+  bbb: ccc
+baz:
+  #x comment
+  #x comment2
+  x: 10
+`
+		actual := "\n" + string(b)
+		if expected != actual {
+			t.Fatalf("expected:%s but got %s", expected, actual)
+		}
+	})
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -383,7 +383,7 @@ a: 1
 	}
 }
 
-func Test_CommentMapOption(t *testing.T) {
+func Test_WithCommentOption(t *testing.T) {
 	v := struct {
 		Foo string                 `yaml:"foo"`
 		Bar map[string]interface{} `yaml:"bar"`


### PR DESCRIPTION
Add option for encoding with comment .

Please see the following test case .
https://github.com/goccy/go-yaml/blob/3c954f0f01dfb5fa49a6f15e838b49046ea62989/yaml_test.go#L386-L468

`yaml.WithComment` is a option for encoding with comment .
The position where you want to add a comment is represented by `YAMLPath`, and it is the key of `yaml.CommentMap` .
Also, you can select `Head` comment or `Line` comment as the comment type.