### PR TITLE
migrate to codecov orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
-version: 2
+version: 2.1
+
+orbs:
+  codecov: codecov/codecov@1.2.5
+
 jobs:
   test:
     working_directory: /go/src/github.com/goccy/go-yaml
@@ -17,11 +21,7 @@ jobs:
           name: Download modules
           command: |
             go mod download
-      - run:
-          name: Run unit tests and measure coverage
-          command: |
-            go test -v -coverprofile=coverage.out ./...
-            bash <(curl -s https://codecov.io/bash) -P ${CIRCLE_PULL_REQUEST##*/}
+      - codecov/upload
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ jobs:
           name: Download modules
           command: |
             go mod download
+      - run:
+          name: Run unit tests
+          command: |
+            go test -v -coverprofile=coverage.out ./...
       - codecov/upload
 workflows:
   version: 2


### PR DESCRIPTION
The bash uploader for codecov is now deprecated due to the [recent security incident](https://about.codecov.io/security-update/).

> https://docs.codecov.com/docs/about-the-codecov-bash-uploader
> Deprecation Notice
> 
> Support for the Bash Uploader will be deprecated on February 1st, 2022.
> 
> Please refer to the main Codecov Uploader page for implementation and upgrades.

We should migrate to the new uploader.

> https://about.codecov.io/blog/introducing-codecovs-new-uploader/
> Our New Uploader (Beta)
> We’ve created an entirely new Uploader using NodeJS that is shipped as a static binary executable on the Windows, Linux, Alpine Linux, and macOS operating systems. Currently, this uploader is in beta, but most standard workflows that are currently accomplished with the Bash Uploader can be accomplished with the new Uploader.
> 
> With its beta release, the new Uploader is now the standard, first-party method to upload coverage (and other related data) to Codecov.
> 
> We will be deprecating all other language-specific uploaders, with special attention paid to the deprecation of the Bash Uploader (see Bash Uploader Deprecation Roadmap below)

Currently, Codecov CircleCI Orb is just a wrapper of the bash uploader.
However, Codecov says that they will be modifying these wrappers in the future to use the new Uploader instead.

> Fundamentally, each of these wrappers invokes the Bash Uploader to upload coverage report files and other information to Codecov. 
> 
> We will be modifying these wrappers in the future to use the new Uploader instead. A specific timeline on these changes is yet to be released, but this work will be accomplished before the Bash Uploader enters its brownout deprecation period. Today: GitHub Actions, Bitrise Step, CircleCI Orb

Migrating CircleCI orb makes easier to introduce the new Uploader.