### PR TITLE
fix bug in encoding nested sequences with IndentSequence

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -417,10 +417,10 @@ func (e *Encoder) encodeBool(v bool) ast.Node {
 }
 
 func (e *Encoder) encodeSlice(ctx context.Context, value reflect.Value) (ast.Node, error) {
-	column := e.column
 	if e.indentSequence {
-		column += e.indent
+		e.column += e.indent
 	}
+	column := e.column
 	sequence := ast.Sequence(token.New("-", "-", e.pos(column)), e.isFlowStyle)
 	for i := 0; i < value.Len(); i++ {
 		node, err := e.encodeValue(ctx, value.Index(i), column)
@@ -429,14 +429,17 @@ func (e *Encoder) encodeSlice(ctx context.Context, value reflect.Value) (ast.Nod
 		}
 		sequence.Values = append(sequence.Values, node)
 	}
+	if e.indentSequence {
+		e.column -= e.indent
+	}
 	return sequence, nil
 }
 
 func (e *Encoder) encodeArray(ctx context.Context, value reflect.Value) (ast.Node, error) {
-	column := e.column
 	if e.indentSequence {
-		column += e.indent
+		e.column += e.indent
 	}
+	column := e.column
 	sequence := ast.Sequence(token.New("-", "-", e.pos(column)), e.isFlowStyle)
 	for i := 0; i < value.Len(); i++ {
 		node, err := e.encodeValue(ctx, value.Index(i), column)
@@ -444,6 +447,9 @@ func (e *Encoder) encodeArray(ctx context.Context, value reflect.Value) (ast.Nod
 			return nil, errors.Wrapf(err, "failed to encode value for array")
 		}
 		sequence.Values = append(sequence.Values, node)
+	}
+	if e.indentSequence {
+		e.column -= e.indent
 	}
 	return sequence, nil
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -222,7 +222,7 @@ func TestEncoder(t *testing.T) {
 			nil,
 		},
 		{
-			"v:\n  - A\n  - 1\n  - B:\n    - 2\n    - 3\n",
+			"v:\n  - A\n  - 1\n  - B:\n      - 2\n      - 3\n  - 2\n",
 			map[string]interface{}{
 				"v": []interface{}{
 					"A",
@@ -230,6 +230,7 @@ func TestEncoder(t *testing.T) {
 					map[string][]int{
 						"B": {2, 3},
 					},
+					2,
 				},
 			},
 			[]yaml.EncodeOption{


### PR DESCRIPTION
There was a bug in the test as well as in the code. The test looked right because it looks like there is indentation before the list items, but the indentation actually comes from the map (B). With this option on, there should be double indentation here. I added another element after the list to make sure I'm not breaking indentation on following items.

old test:
```
v:
  - A
  - 1
  - B:
    - 2
    - 3
```

new test:

```
v:
  - A
  - 1
  - B:
      - 2
      - 3
  - 2
```