### PR TITLE
Fix error reporting on inline structs in strict mode (#243)

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -981,7 +981,7 @@ func (d *Decoder) decodeStruct(ctx context.Context, dst reflect.Value, src ast.N
 					err = nil
 				}
 
-				if err = d.deleteStructKeys(fieldValue.Type(), unknownFields); err != nil {
+				if err := d.deleteStructKeys(fieldValue.Type(), unknownFields); err != nil {
 					return errors.Wrapf(err, "cannot delete struct keys")
 				}
 			}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1454,6 +1454,32 @@ c: true
 	}
 }
 
+func TestDecoder_InlineAndWrongTypeStrict(t *testing.T) {
+	type Base struct {
+		A int
+		B string
+	}
+	yml := `---
+a: notanint
+b: hello
+c: true
+`
+	var v struct {
+		*Base `yaml:",inline"`
+		C     bool
+	}
+	err := yaml.NewDecoder(strings.NewReader(yml), yaml.Strict()).Decode(&v)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	//TODO: properly check if errors are colored/have source
+	t.Logf("%s", err)
+	t.Logf("%s", yaml.FormatError(err, true, false))
+	t.Logf("%s", yaml.FormatError(err, false, true))
+	t.Logf("%s", yaml.FormatError(err, true, true))
+}
+
 func TestDecoder_InvalidCases(t *testing.T) {
 	const src = `---
 a:


### PR DESCRIPTION
Errors from inline structs were getting lost in strict mode.