### PR TITLE
Fix encoding of large floats

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -384,7 +384,7 @@ func (e *Encoder) encodeFloat(v float64, bitSize int) ast.Node {
 		return ast.Nan(token.New(value, value, e.pos(e.column)))
 	}
 	value := strconv.FormatFloat(v, 'g', -1, bitSize)
-	if !strings.Contains(value, ".") {
+	if !strings.Contains(value, ".") && !strings.Contains(value, "e") {
 		// append x.0 suffix to keep float value context
 		value = fmt.Sprintf("%s.0", value)
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -94,6 +94,11 @@ func TestEncoder(t *testing.T) {
 			nil,
 		},
 		{
+			"v: 1e+06\n",
+			map[string]float64{"v": 1000000},
+			nil,
+		},
+		{
 			"v: .inf\n",
 			map[string]interface{}{"v": math.Inf(0)},
 			nil,


### PR DESCRIPTION
An extra `.0` was getting appended when the value of the float was a power of 10.