### PR TITLE
Support getting YAMLPath from ast.Node

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -179,6 +179,10 @@ type Node interface {
 	SetComment(*CommentGroupNode) error
 	// Comment returns comment token instance
 	GetComment() *CommentGroupNode
+	// GetPath returns YAMLPath for the current node
+	GetPath() string
+	// SetPath set YAMLPath for the current node
+	SetPath(string)
 	// MarshalYAML
 	MarshalYAML() ([]byte, error)
 	// already read length
@@ -198,6 +202,7 @@ type ScalarNode interface {
 }
 
 type BaseNode struct {
+	Path    string
 	Comment *CommentGroupNode
 	read    int
 }
@@ -216,6 +221,22 @@ func (n *BaseNode) clearLen() {
 
 func (n *BaseNode) addReadLen(len int) {
 	n.read += len
+}
+
+// GetPath returns YAMLPath for the current node.
+func (n *BaseNode) GetPath() string {
+	if n == nil {
+		return ""
+	}
+	return n.Path
+}
+
+// SetPath set YAMLPath for the current node.
+func (n *BaseNode) SetPath(path string) {
+	if n == nil {
+		return
+	}
+	n.Path = path
 }
 
 // GetComment returns comment token instance
@@ -1916,40 +1937,68 @@ func Walk(v Visitor, node Node) {
 	switch n := node.(type) {
 	case *CommentNode:
 	case *NullNode:
+		walkComment(v, n.BaseNode)
 	case *IntegerNode:
+		walkComment(v, n.BaseNode)
 	case *FloatNode:
+		walkComment(v, n.BaseNode)
 	case *StringNode:
+		walkComment(v, n.BaseNode)
 	case *MergeKeyNode:
+		walkComment(v, n.BaseNode)
 	case *BoolNode:
+		walkComment(v, n.BaseNode)
 	case *InfinityNode:
+		walkComment(v, n.BaseNode)
 	case *NanNode:
+		walkComment(v, n.BaseNode)
 	case *LiteralNode:
+		walkComment(v, n.BaseNode)
 		Walk(v, n.Value)
 	case *DirectiveNode:
+		walkComment(v, n.BaseNode)
 		Walk(v, n.Value)
 	case *TagNode:
+		walkComment(v, n.BaseNode)
 		Walk(v, n.Value)
 	case *DocumentNode:
+		walkComment(v, n.BaseNode)
 		Walk(v, n.Body)
 	case *MappingNode:
+		walkComment(v, n.BaseNode)
 		for _, value := range n.Values {
 			Walk(v, value)
 		}
 	case *MappingKeyNode:
+		walkComment(v, n.BaseNode)
 		Walk(v, n.Value)
 	case *MappingValueNode:
+		walkComment(v, n.BaseNode)
 		Walk(v, n.Key)
 		Walk(v, n.Value)
 	case *SequenceNode:
+		walkComment(v, n.BaseNode)
 		for _, value := range n.Values {
 			Walk(v, value)
 		}
 	case *AnchorNode:
+		walkComment(v, n.BaseNode)
 		Walk(v, n.Name)
 		Walk(v, n.Value)
 	case *AliasNode:
+		walkComment(v, n.BaseNode)
 		Walk(v, n.Value)
 	}
+}
+
+func walkComment(v Visitor, base *BaseNode) {
+	if base == nil {
+		return
+	}
+	if base.Comment == nil {
+		return
+	}
+	Walk(v, base.Comment)
 }
 
 type filterWalker struct {

--- a/parser/context.go
+++ b/parser/context.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/goccy/go-yaml/token"
 )
@@ -16,8 +17,29 @@ type context struct {
 	path   string
 }
 
+var pathSpecialChars = []string{
+	"$", "*", ".", "[", "]",
+}
+
+func containsPathSpecialChar(path string) bool {
+	for _, char := range pathSpecialChars {
+		if strings.Contains(path, char) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizePath(path string) string {
+	if containsPathSpecialChar(path) {
+		return fmt.Sprintf("'%s'", path)
+	}
+	return path
+}
+
 func (c *context) withChild(path string) *context {
 	ctx := c.copy()
+	path = normalizePath(path)
 	ctx.path += fmt.Sprintf(".%s", path)
 	return ctx
 }

--- a/parser/context.go
+++ b/parser/context.go
@@ -1,13 +1,42 @@
 package parser
 
-import "github.com/goccy/go-yaml/token"
+import (
+	"fmt"
+
+	"github.com/goccy/go-yaml/token"
+)
 
 // context context at parsing
 type context struct {
+	parent *context
 	idx    int
 	size   int
 	tokens token.Tokens
 	mode   Mode
+	path   string
+}
+
+func (c *context) withChild(path string) *context {
+	ctx := c.copy()
+	ctx.path += fmt.Sprintf(".%s", path)
+	return ctx
+}
+
+func (c *context) withIndex(idx uint) *context {
+	ctx := c.copy()
+	ctx.path += fmt.Sprintf("[%d]", idx)
+	return ctx
+}
+
+func (c *context) copy() *context {
+	return &context{
+		parent: c,
+		idx:    c.idx,
+		size:   c.size,
+		tokens: append(token.Tokens{}, c.tokens...),
+		mode:   c.mode,
+		path:   c.path,
+	}
 }
 
 func (c *context) next() bool {
@@ -22,6 +51,9 @@ func (c *context) previousToken() *token.Token {
 }
 
 func (c *context) insertToken(idx int, tk *token.Token) {
+	if c.parent != nil {
+		c.parent.insertToken(idx, tk)
+	}
 	if c.size < idx {
 		return
 	}
@@ -104,6 +136,9 @@ func (c *context) isCurrentCommentToken() bool {
 }
 
 func (c *context) progressIgnoreComment(num int) {
+	if c.parent != nil {
+		c.parent.progressIgnoreComment(num)
+	}
 	if c.size <= c.idx+num {
 		c.idx = c.size
 	} else {
@@ -135,5 +170,6 @@ func newContext(tokens token.Tokens, mode Mode) *context {
 		size:   len(filteredTokens),
 		tokens: filteredTokens,
 		mode:   mode,
+		path:   "$",
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -775,6 +775,7 @@ a: # commentA
    - list3 # comment list3
   i: fuga # commentI
 j: piyo # commentJ
+k.l.m.n: moge # commentKLMN
 `
 	f, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
 	if err != nil {
@@ -804,6 +805,7 @@ j: piyo # commentJ
 		"$.a.h[2]",
 		"$.a.i",
 		"$.j",
+		"$.'k.l.m.n'",
 	}
 	if !reflect.DeepEqual(expectedPaths, commentPaths) {
 		t.Fatalf("failed to get YAMLPath to the comment node:\nexpected[%s]\ngot     [%s]", expectedPaths, commentPaths)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3,12 +3,14 @@ package parser_test
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/lexer"
 	"github.com/goccy/go-yaml/parser"
+	"github.com/goccy/go-yaml/token"
 )
 
 func TestParser(t *testing.T) {
@@ -756,6 +758,71 @@ foo: > # comment
 			}
 		})
 	}
+}
+
+func TestNodePath(t *testing.T) {
+	yml := `
+a: # commentA
+  b: # commentB
+    c: foo # commentC
+    d: bar # commentD
+    e: baz # commentE
+  f: # commentF
+    g: hoge # commentG
+  h: # commentH
+   - list1 # comment list1
+   - list2 # comment list2
+   - list3 # comment list3
+  i: fuga # commentI
+j: piyo # commentJ
+`
+	f, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	var capturer pathCapturer
+	for _, doc := range f.Docs {
+		ast.Walk(&capturer, doc.Body)
+	}
+	commentPaths := []string{}
+	for i := 0; i < capturer.capturedNum; i++ {
+		if capturer.orderedTypes[i] == ast.CommentType {
+			commentPaths = append(commentPaths, capturer.orderedPaths[i])
+		}
+	}
+	expectedPaths := []string{
+		"$.a",
+		"$.a.b",
+		"$.a.b.c",
+		"$.a.b.d",
+		"$.a.b.e",
+		"$.a.f",
+		"$.a.f.g",
+		"$.a.h",
+		"$.a.h[0]",
+		"$.a.h[1]",
+		"$.a.h[2]",
+		"$.a.i",
+		"$.j",
+	}
+	if !reflect.DeepEqual(expectedPaths, commentPaths) {
+		t.Fatalf("failed to get YAMLPath to the comment node:\nexpected[%s]\ngot     [%s]", expectedPaths, commentPaths)
+	}
+}
+
+type pathCapturer struct {
+	capturedNum   int
+	orderedPaths  []string
+	orderedTypes  []ast.NodeType
+	orderedTokens []*token.Token
+}
+
+func (c *pathCapturer) Visit(node ast.Node) ast.Visitor {
+	c.capturedNum++
+	c.orderedPaths = append(c.orderedPaths, node.GetPath())
+	c.orderedTypes = append(c.orderedTypes, node.Type())
+	c.orderedTokens = append(c.orderedTokens, node.GetToken())
+	return c
 }
 
 type Visitor struct {


### PR DESCRIPTION
Support `GetPath() string` API to the `ast.Node` .
This API allows you to get the YAMLPath from `ast.Node` .
