### PR TITLE
Support CommentToMap option

### DIFF
--- a/error.go
+++ b/error.go
@@ -11,6 +11,7 @@ var (
 	ErrInvalidPathString          = xerrors.New("invalid path string")
 	ErrNotFoundNode               = xerrors.New("node not found")
 	ErrUnknownCommentPositionType = xerrors.New("unknown comment position type")
+	ErrInvalidCommentMapValue     = xerrors.New("invalid comment map value. it must be not nil value")
 )
 
 func ErrUnsupportedHeadPositionType(node ast.Node) error {

--- a/option.go
+++ b/option.go
@@ -216,3 +216,14 @@ func WithComment(cm CommentMap) EncodeOption {
 		return nil
 	}
 }
+
+// CommentToMap apply the position and content of comments in a YAML document to a CommentMap.
+func CommentToMap(cm CommentMap) DecodeOption {
+	return func(d *Decoder) error {
+		if cm == nil {
+			return ErrInvalidCommentMapValue
+		}
+		d.toCommentMap = cm
+		return nil
+	}
+}


### PR DESCRIPTION
The `yaml.CommentToMap` option is a companion option to `yaml.WithComment` .
By using this option record the comment information in the YAML to the CommentMap and use that information as it is in `yaml.WithComment`, it is possible to perform reversible conversion of YAML with comments.