### PR TITLE
Fix minor typo in decodeInit error

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1540,7 +1540,7 @@ func (d *Decoder) DecodeContext(ctx context.Context, v interface{}) error {
 		return nil
 	}
 	if err := d.decodeInit(); err != nil {
-		return errors.Wrapf(err, "failed to decodInit")
+		return errors.Wrapf(err, "failed to decodeInit")
 	}
 	if err := d.decode(ctx, rv); err != nil {
 		if err == io.EOF {


### PR DESCRIPTION
Updates error to read 'decodeInit' rather than 'decodInit'.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>