### PR TITLE
Handle empty sequence entries

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -281,6 +281,9 @@ func (p *parser) parseSequenceEntry(ctx *context) (ast.Node, error) {
 	for tk.Type == token.SequenceEntryType {
 		ctx.progress(1) // skip sequence token
 		tk = ctx.currentToken()
+		if tk == nil {
+			return nil, errors.ErrSyntax("empty sequence entry", ctx.previousToken())
+		}
 		var comment *ast.CommentGroupNode
 		if tk.Type == token.CommentType {
 			comment = p.parseCommentOnly(ctx)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -645,6 +645,19 @@ a
        ^
 `,
 		},
+		{
+			`
+a:
+- b: c
+- `,
+			`
+[4:1] empty sequence entry
+   2 | a:
+   3 | - b: c
+>  4 | -
+       ^
+`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.source, func(t *testing.T) {


### PR DESCRIPTION
- adds a nil check for tk, and returns a syntax error if nil is found
- adds a test verifying fix

Signed-off-by: Taylor Thornton <thornton.tn@gmail.com>

fixes: #274 