### PR TITLE
Fix encoding of sequence with multiline string

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1586,6 +1586,12 @@ func (n *SequenceNode) blockStyleString() string {
 		splittedValues := strings.Split(valueStr, "\n")
 		trimmedFirstValue := strings.TrimLeft(splittedValues[0], " ")
 		diffLength := len(splittedValues[0]) - len(trimmedFirstValue)
+		if len(splittedValues) > 1 && value.Type() == StringType || value.Type() == LiteralType {
+			// If multi-line string, the space characters for indent have already been added, so delete them.
+			for i := 1; i < len(splittedValues); i++ {
+				splittedValues[i] = strings.TrimLeft(splittedValues[i], " ")
+			}
+		}
 		newValues := []string{trimmedFirstValue}
 		for i := 1; i < len(splittedValues); i++ {
 			if len(splittedValues[i]) <= diffLength {

--- a/encode_test.go
+++ b/encode_test.go
@@ -1302,3 +1302,49 @@ func Example_MarshalYAML() {
 	//
 	// field: 13
 }
+
+func TestMarshalIndentWithMultipleText(t *testing.T) {
+	t.Run("depth1", func(t *testing.T) {
+		b, err := yaml.MarshalWithOptions(map[string]interface{}{
+			"key": []string{`line1
+line2
+line3`},
+		}, yaml.Indent(2))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(b)
+		expected := `key:
+- |-
+  line1
+  line2
+  line3
+`
+		if expected != got {
+			t.Fatalf("failed to encode.\nexpected:\n%s\nbut got:\n%s\n", expected, got)
+		}
+	})
+	t.Run("depth2", func(t *testing.T) {
+		b, err := yaml.MarshalWithOptions(map[string]interface{}{
+			"key": map[string]interface{}{
+				"key2": []string{`line1
+line2
+line3`},
+			},
+		}, yaml.Indent(2))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(b)
+		expected := `key:
+  key2:
+  - |-
+    line1
+    line2
+    line3
+`
+		if expected != got {
+			t.Fatalf("failed to encode.\nexpected:\n%s\nbut got:\n%s\n", expected, got)
+		}
+	})
+}


### PR DESCRIPTION
Currently, there is a problem that indentation becomes deeper than necessary when using sequences with multiple strings.
This PR fixes this problem .