### PR TITLE
yaml: typeError implements PrettyPrinter interface

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1074,8 +1074,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal string into Go struct field T.A of type int"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 		})
 		t.Run("string to bool", func(t *testing.T) {
@@ -1085,8 +1085,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal string into Go struct field T.D of type bool"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 		})
 		t.Run("string to int at inline", func(t *testing.T) {
@@ -1096,8 +1096,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal string into Go struct field U.T.A of type int"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 		})
 	})
@@ -1109,8 +1109,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal string into Go value of type int"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 			if len(v) == 0 || len(v["v"]) == 0 {
 				t.Fatal("failed to decode value")
@@ -1126,8 +1126,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal string into Go value of type int"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 			if len(v) == 0 || len(v["v"]) == 0 {
 				t.Fatal("failed to decode value")
@@ -1145,8 +1145,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal -42 into Go value of type uint ( overflow )"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 			if v["v"] != 0 {
 				t.Fatal("failed to decode value")
@@ -1159,8 +1159,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal -4294967296 into Go value of type uint64 ( overflow )"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 			if v["v"] != 0 {
 				t.Fatal("failed to decode value")
@@ -1173,8 +1173,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal 4294967297 into Go value of type int32 ( overflow )"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 			if v["v"] != 0 {
 				t.Fatal("failed to decode value")
@@ -1187,8 +1187,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal 128 into Go value of type int8 ( overflow )"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 			if v["v"] != 0 {
 				t.Fatal("failed to decode value")
@@ -1207,8 +1207,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal uint64 into Go struct field T.A of type time.Time"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 		})
 		t.Run("string to duration", func(t *testing.T) {
@@ -1218,8 +1218,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := `time: invalid duration "str"`
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 		})
 		t.Run("int to duration", func(t *testing.T) {
@@ -1229,8 +1229,8 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatal("expected to error")
 			}
 			msg := "cannot unmarshal uint64 into Go struct field T.B of type time.Duration"
-			if err.Error() != msg {
-				t.Fatalf("unexpected error message: %s. expect: %s", err.Error(), msg)
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 		})
 	})

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -67,10 +67,10 @@ type wrapError struct {
 	frame   xerrors.Frame
 }
 
-type myprinter struct {
+type FormatErrorPrinter struct {
 	xerrors.Printer
-	colored    bool
-	inclSource bool
+	Colored    bool
+	InclSource bool
 }
 
 func (e *wrapError) As(target interface{}) bool {
@@ -90,15 +90,15 @@ func (e *wrapError) Unwrap() error {
 }
 
 func (e *wrapError) PrettyPrint(p xerrors.Printer, colored, inclSource bool) error {
-	return e.FormatError(&myprinter{Printer: p, colored: colored, inclSource: inclSource})
+	return e.FormatError(&FormatErrorPrinter{Printer: p, Colored: colored, InclSource: inclSource})
 }
 
 func (e *wrapError) FormatError(p xerrors.Printer) error {
-	if _, ok := p.(*myprinter); !ok {
-		p = &myprinter{
+	if _, ok := p.(*FormatErrorPrinter); !ok {
+		p = &FormatErrorPrinter{
 			Printer:    p,
-			colored:    defaultColorize,
-			inclSource: defaultIncludeSource,
+			Colored:    defaultColorize,
+			InclSource: defaultIncludeSource,
 		}
 	}
 	if e.verb == 'v' && e.state.Flag('+') {
@@ -171,16 +171,16 @@ type syntaxError struct {
 }
 
 func (e *syntaxError) PrettyPrint(p xerrors.Printer, colored, inclSource bool) error {
-	return e.FormatError(&myprinter{Printer: p, colored: colored, inclSource: inclSource})
+	return e.FormatError(&FormatErrorPrinter{Printer: p, Colored: colored, InclSource: inclSource})
 }
 
 func (e *syntaxError) FormatError(p xerrors.Printer) error {
 	var pp printer.Printer
 
 	var colored, inclSource bool
-	if mp, ok := p.(*myprinter); ok {
-		colored = mp.colored
-		inclSource = mp.inclSource
+	if fep, ok := p.(*FormatErrorPrinter); ok {
+		colored = fep.Colored
+		inclSource = fep.InclSource
 	}
 
 	pos := fmt.Sprintf("[%d:%d] ", e.token.Position.Line, e.token.Position.Column)

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 
 	"github.com/goccy/go-yaml/printer"
 	"github.com/goccy/go-yaml/token"
@@ -219,4 +220,41 @@ func (e *syntaxError) Error() string {
 	var buf bytes.Buffer
 	e.PrettyPrint(&Sink{&buf}, defaultColorize, defaultIncludeSource)
 	return buf.String()
+}
+
+type TypeError struct {
+	DstType         reflect.Type
+	SrcType         reflect.Type
+	StructFieldName *string
+	Token           *token.Token
+}
+
+func (e *TypeError) Error() string {
+	if e.StructFieldName != nil {
+		return fmt.Sprintf("cannot unmarshal %s into Go struct field %s of type %s", e.SrcType, *e.StructFieldName, e.DstType)
+	}
+	return fmt.Sprintf("cannot unmarshal %s into Go value of type %s", e.SrcType, e.DstType)
+}
+
+func (e *TypeError) PrettyPrint(p xerrors.Printer, colored, inclSource bool) error {
+	return e.FormatError(&FormatErrorPrinter{Printer: p, Colored: colored, InclSource: inclSource})
+}
+
+func (e *TypeError) FormatError(p xerrors.Printer) error {
+	var pp printer.Printer
+
+	var colored, inclSource bool
+	if fep, ok := p.(*FormatErrorPrinter); ok {
+		colored = fep.Colored
+		inclSource = fep.InclSource
+	}
+
+	pos := fmt.Sprintf("[%d:%d] ", e.Token.Position.Line, e.Token.Position.Column)
+	msg := pp.PrintErrorMessage(fmt.Sprintf("%s%s", pos, e.Error()), colored)
+	if inclSource {
+		msg += "\n" + pp.PrintErrorToken(e.Token, colored)
+	}
+	p.Print(msg)
+
+	return nil
 }


### PR DESCRIPTION
When unmarshalling YAML and encountering an error in decoding that
results in a `yaml.typeError`, the error can't have the same nice
formatting because it doesn't implement the `errors.PrettyPrinter`
interface. This adds a field to the `yaml.typeError` struct that
specifies a token which is used in the implementation of the
PrettyPrinter interface. The tests were updated to instead match on
expected message substrings instead of full equality.

For example, when getting an error like this:
`cannot unmarshal uint64 into Go struct field T.B of type time.Duration`
This PR allows for output like this:
```
[1:4] cannot unmarshal uint64 into Go struct field T.B of type time.Duration
>  1 | b: 10
          ^
```