### PR TITLE
fix(typeErr): workaround typeErr structFieldName overwritten

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1090,7 +1090,12 @@ func (d *Decoder) decodeStruct(ctx context.Context, dst reflect.Value, src ast.N
 			}
 			var te *typeError
 			if xerrors.As(err, &te) {
-				fieldName := fmt.Sprintf("%s.%s", structType.Name(), field.Name)
+				var fieldName string
+				if te.structFieldName != nil {
+					fieldName = fmt.Sprintf("%s.%s:%s", structType.Name(), field.Name, *te.structFieldName)
+				} else {
+					fieldName = fmt.Sprintf("%s.%s", structType.Name(), field.Name)
+				}
 				te.structFieldName = &fieldName
 				foundErr = te
 			} else {


### PR DESCRIPTION
If there is a nested struct go unmarshaled, the error message got overwritten. This create confusing error messages. 

For example:

``` go
type ParamEntry struct {
	Required bool `json:"required,omitempty"`
}


type Spec struct {
	Params []ParamEntry `json:"params,omitempty"`
}

var content = `
params:
- required: yes
`

func TestGoyccYaml(t *testing.T)  {
	var s Spec
	err := yaml.UnmarshalWithOptions(
		[]byte(content),
		&s,
		yaml.UseOrderedMap(),
	)
	assert.NilError(t, err)
}
```

While unmarshal this, I go error message like this `cannot unmarshal string into Go struct field Spec.Params of type bool`, when `Spec.Params` is a slice of `ParamEntry`.

I try to concatenate the error, an alternative is to remove the "type" part of the underlying error. I'm submitting for discussion.

Jia

