### PR TITLE
Fix large literals type inference on 32 bits

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -89,7 +89,7 @@ func TestDecoder(t *testing.T) {
 		},
 		{
 			"v: -0b1000000000000000000000000000000000000000000000000000000000000000",
-			map[string]interface{}{"v": -9223372036854775808},
+			map[string]interface{}{"v": int64(-9223372036854775808)},
 		},
 		{
 			"v: 0xA",
@@ -109,7 +109,7 @@ func TestDecoder(t *testing.T) {
 		},
 		{
 			"v: 4294967296\n",
-			map[string]int{"v": 4294967296},
+			map[string]int64{"v": int64(4294967296)},
 		},
 		{
 			"v: 0.1\n",
@@ -200,7 +200,7 @@ func TestDecoder(t *testing.T) {
 			map[string]uint{"v": 42},
 		}, {
 			"v: 4294967296",
-			map[string]uint64{"v": 4294967296},
+			map[string]uint64{"v": uint64(4294967296)},
 		},
 
 		// int

--- a/encode_test.go
+++ b/encode_test.go
@@ -65,7 +65,7 @@ func TestEncoder(t *testing.T) {
 		},
 		{
 			"v: 4294967296\n",
-			map[string]int{"v": 4294967296},
+			map[string]int64{"v": int64(4294967296)},
 			nil,
 		},
 		{


### PR DESCRIPTION
Some tests are failing because some large literal integers are meant to be stored on 64 bits, but are stored on 32 on 32 bits architectures. This causes the value to overflow:
```
# github.com/goccy/go-yaml_test [github.com/goccy/go-yaml.test]
./decode_test.go:92:32: cannot use -9223372036854775808 (untyped int constant) as int value in map literal (overflows)
./decode_test.go:112:24: cannot use 4294967296 (untyped int constant) as int value in map literal (overflows)
./encode_test.go:68:24: cannot use 4294967296 (untyped int constant) as int value in map literal (overflows)
```

This commit fixes this issue by using explicit int64 typing.