### PR TITLE
UTF-8 Support

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -266,7 +266,7 @@ func readNode(p []byte, node Node) (int, error) {
 		return 0, io.EOF
 	}
 	size := min(remain, len(p))
-	for idx, b := range s[readLen : readLen+size] {
+	for idx, b := range []byte(s[readLen : readLen+size]) {
 		p[idx] = byte(b)
 	}
 	node.addReadLen(size)

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -1,6 +1,10 @@
 package ast
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml/token"
+)
 
 func TestEscapeSingleQuote(t *testing.T) {
 	expected := `'Victor''s victory'`
@@ -8,4 +12,25 @@ func TestEscapeSingleQuote(t *testing.T) {
 	if got != expected {
 		t.Fatalf("expected:%s\ngot:%s", expected, got)
 	}
+}
+
+func TestReadNode(t *testing.T) {
+	t.Run("utf-8", func(t *testing.T) {
+		value := "éɛทᛞ⠻チ▓🦄"
+		node := &StringNode{
+			BaseNode: &BaseNode{},
+			Token:    &token.Token{},
+			Value:    value,
+		}
+		expectedSize := len(value)
+		gotBuffer := make([]byte, expectedSize)
+		expectedBuffer := []byte(value)
+		gotSize, _ := readNode(gotBuffer, node)
+		if gotSize != expectedSize {
+			t.Fatalf("expected size:%d\ngot:%d", expectedSize, gotSize)
+		}
+		if string(gotBuffer) != string(expectedBuffer) {
+			t.Fatalf("expected buffer:%s\ngot:%s", expectedBuffer, gotBuffer)
+		}
+	})
 }


### PR DESCRIPTION
Right now, utf-8 support is broken, because of golang behavior when looping with a range on string in ast `readNode` function

https://github.com/goccy/go-yaml/blob/e4f32a26722ce33ac79a7b4ad88c26fd0b9c2995/ast/ast.go#L269

In this case, range loop over string *runes* and not string *bytes*. As a consequence, the resulting buffer bytes does not correspond to the string bytes themselves.

See the results on https://go.dev/play/p/5pWTN0y4vUj

Fortunately, a simple byte casting fix the issue :)

```golang
	for idx, b := range []byte(s[readLen : readLen+size]) {
		p[idx] = byte(b)
	}
```

A test has been provided with obscure utf-8 characters.
