### PR TITLE
Encode `ast.StringNode` line comment after header

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -829,6 +829,9 @@ func (n *StringNode) String() string {
 		// This block assumes that the line breaks in this inside scalar content and the Outside scalar content are the same.
 		// It works mostly, but inconsistencies occur if line break characters are mixed.
 		header := token.LiteralBlockHeader(n.Value)
+		if n.Comment != nil {
+			header = addCommentString(header, n.Comment)
+		}
 		space := strings.Repeat(" ", n.Token.Position.Column-1)
 		values := []string{}
 		for _, v := range strings.Split(n.Value, lbc) {


### PR DESCRIPTION
Currently, if a `ast.StringNode` is multiline, it does not encode its line comment. This PR adds the comment after the block header similarly to `ast.LiteralNode`.

Block comments are allowed in the YAML 1.2 spec: https://yaml.org/spec/1.2-old/spec.html#id2793718, but block header comments _must_ only be a single line. This PR conforms to the logic added in https://github.com/goccy/go-yaml/pull/234.

## Example
```go
package main

import (
	"fmt"
	"github.com/goccy/go-yaml/ast"
	"github.com/goccy/go-yaml/parser"
)

func main() {
	source := "test: hello world #comment\n"

	file, err := parser.ParseBytes([]byte(source), parser.ParseComments)
	if err != nil {
		panic(err)
	}

	file.Docs[0].Body.(*ast.MappingValueNode).Value.(*ast.StringNode).Value = "test\nmultiline"
	fmt.Println(file)
}

```

### Output
```yaml
test: |-
        test
        multiline
```

### Expected
```yaml
test: |- #comment
        test
        multiline

```