### PR TITLE
partial fix for #298: path.Replace: support anchors

### DIFF
--- a/path.go
+++ b/path.go
@@ -336,7 +336,7 @@ func (p *Path) ReplaceWithFile(dst *ast.File, src *ast.File) error {
 	return nil
 }
 
-// ReplaceNode replace ast.File with ast.Node.
+// ReplaceWithNode replace ast.File with ast.Node.
 func (p *Path) ReplaceWithNode(dst *ast.File, node ast.Node) error {
 	for _, doc := range dst.Docs {
 		if node.Type() == ast.DocumentType {

--- a/path.go
+++ b/path.go
@@ -564,6 +564,9 @@ func (n *selectorNode) replace(node ast.Node, target ast.Node) error {
 		if err := n.replaceMapValue(value, target); err != nil {
 			return errors.Wrapf(err, "failed to replace map value")
 		}
+	case ast.AnchorType:
+		return n.replace(node.(*ast.AnchorNode).Value, target)
+
 	default:
 		return errors.Wrapf(ErrInvalidQuery, "expected node type is map or map value. but got %s", node.Type())
 	}

--- a/path_test.go
+++ b/path_test.go
@@ -510,6 +510,20 @@ building:
   author: ken
 `,
 		},
+		{
+			path: "$.a.a1",
+			dst: `
+a: &a-anchor
+  a1: foo
+b: *a-anchor
+`,
+			src: `bar`,
+			expected: `
+a: &a-anchor
+  a1: bar
+b: *a-anchor
+`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.path, func(t *testing.T) {


### PR DESCRIPTION
With reference to #298:

Now the path.Replace* functions do not error out any more, but the returned node is
rendered without a newline, thus producing a broken YAML:

    expected: "\na: &a-anchor\n  a1: bar\nb: *a-anchor\n".
    but got   "\na: &a-anchor   a1: bar\nb: *a-anchor\n"

which rendered with the newlines becomes:

```
expected:
"
a: &a-anchor
  a1: bar
  b: *a-anchor
"

but got:
"
a: &a-anchor   a1: bar
b: *a-anchor
"
```

Am I going in the right direction?