### PR TITLE
example: add Go fuzz for PathList

### DIFF
--- a/path.go
+++ b/path.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/internal/errors"
@@ -101,6 +102,11 @@ func parsePathDot(b *PathBuilder, buf []rune, cursor int) (*PathBuilder, []rune,
 	}
 	for ; cursor < length; cursor++ {
 		c := buf[cursor]
+		// Not a proper fix; here just to show the problem.
+		// Should be fixed with an explicit allow list instead of an explicit deny list.
+		if unicode.IsDigit(c) {
+			return nil, nil, 0, errors.Wrapf(ErrInvalidPathString, "specified digit after '.' character")
+		}
 		switch c {
 		case '$':
 			return nil, nil, 0, errors.Wrapf(ErrInvalidPathString, "specified '$' after '.' character")

--- a/path.go
+++ b/path.go
@@ -114,7 +114,7 @@ func parsePathDot(b *PathBuilder, buf []rune, cursor int) (*PathBuilder, []rune,
 	}
 end:
 	if start == cursor {
-		return nil, nil, 0, errors.Wrapf(ErrInvalidPathString, "cloud not find by empty key")
+		return nil, nil, 0, errors.Wrapf(ErrInvalidPathString, "could not find by empty key")
 	}
 	return b.child(string(buf[start:cursor])), buf, cursor, nil
 }

--- a/path_test.go
+++ b/path_test.go
@@ -657,3 +657,44 @@ store:
 	// OUTPUT:
 	// [john ken]
 }
+
+func TestPathStringCrashes(t *testing.T) {
+	testCases := []string{
+		".0",
+		".AA",
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			_, err := yaml.PathString(tc)
+			if err == nil {
+				t.Fatalf("have: no error; want: error")
+			}
+		})
+	}
+}
+
+func FuzzPathString(f *testing.F) {
+	corpus := []string{
+		`$.a.b[0]`,
+		`$.'a.b'.'c*d'`,
+		`$.'a.b-*'.c`,
+		`$.'a'.b`,
+		`$.'a.b'.c`,
+		"$..a",
+		"$.a.b..c",
+		`$.'a.b.c'.foo`,
+		`$.a'b`,
+		`$.''`,
+		"$.a[*].b=x",
+	}
+	for _, tc := range corpus {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, sPath string) {
+		_, err := yaml.PathString(sPath)
+		if err != nil {
+			return
+		}
+	})
+}


### PR DESCRIPTION
Hello,

this PR shows a problem with input validation in go-yaml by adding a Go fuzz target.
If you are not familiar with Go 1.18 fuzzy tests, see https://tip.golang.org/doc/tutorial/fuzz.

The main problem is that the code does input validation with a deny list, while for robustness
it should do the opposite, use an explicit allow list. See for example
https://guides.codepath.org/websecurity/Prefer-whitelisting-over-blacklisting

This PR is not meant to be merged as-is; it is only a suggestion for how you could make
go-yaml more robust.