### PR TITLE
Introduce MapKeyNode interface to limit node types for map key

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -104,7 +104,7 @@ func (d *Decoder) mergeValueNode(value ast.Node) ast.Node {
 	return value
 }
 
-func (d *Decoder) mapKeyNodeToString(node ast.Node) string {
+func (d *Decoder) mapKeyNodeToString(node ast.MapKeyNode) string {
 	key := d.nodeToValue(node)
 	if key == nil {
 		return "null"
@@ -283,7 +283,7 @@ func (d *Decoder) resolveAlias(node ast.Node) ast.Node {
 			value.AddColumn(requiredColumn)
 			n.Value = value
 		} else {
-			n.Key = d.resolveAlias(n.Key)
+			n.Key = d.resolveAlias(n.Key).(ast.MapKeyNode)
 			n.Value = d.resolveAlias(n.Value)
 		}
 	case *ast.SequenceNode:


### PR DESCRIPTION
This pull request introduces `ast.MapKeyNode` interface for the following reasons.

- There are only limited node types for map keys. For example `MappingValueNode` never allowed as a map key. But current AST allows to create such unexpected maps. This PR changes the argument `key` of `ast.MappingValue` to `ast.MapKeyNode` to prohibit creating unexpected maps.
- In the `ast` package, `stringWithoutComment() string` is implemented for all node types, but this method is only required for map key types. `CommentNode` having `stringWithoutComment` looks very weird. So I removed all the unnecessary `stringWithoutComment` implementations.

For `ast` package users, following is the complete list of the changes.

- New interface `ast.MapKeyNode` is introduced. All the node types implementing `ast.ScalarNode` and `ast.MergeKeyNode`, `ast.MappingKeyNode` satisfy `ast.MapKeyNode`. Note that `ast.LiteralNode` never appears as map key but is a scalar node thus satisfies `ast.MapKeyNode`.
- `ast.Null`, `ast.Bool`, `ast.Integer`, `ast.Float` now return the concrete types instead of `ast.Node` (Ref: [_The implementing package should return concrete (usually pointer or struct) types_](https://github.com/golang/go/wiki/CodeReviewComments#interfaces)). 
- `ast.MappingValue` now accepts `key ast.MapKeyNode` instead of `ast.Node`. Also, `func (*MapNodeIter) Key()` now returns `ast.MapKeyNode` instead of `ast.Node`.