### PR TITLE
fix: insert a separator between each encoded document

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -39,6 +39,7 @@ type Encoder struct {
 	anchorPtrToNameMap         map[uintptr]string
 	useLiteralStyleIfMultiline bool
 	commentMap                 map[*Path]*Comment
+	written                    bool
 
 	line        int
 	column      int
@@ -85,6 +86,12 @@ func (e *Encoder) EncodeContext(ctx context.Context, v interface{}) error {
 	}
 	if err := e.setCommentByCommentMap(node); err != nil {
 		return errors.Wrapf(err, "failed to set comment by comment map")
+	}
+	if !e.written {
+		e.written = true
+	} else {
+		// write document separator
+		e.writer.Write([]byte("---\n"))
 	}
 	var p printer.Printer
 	e.writer.Write(p.PrintNode(node))

--- a/encode_test.go
+++ b/encode_test.go
@@ -1094,6 +1094,20 @@ a:
 	}
 }
 
+func TestEncoder_MultipleDocuments(t *testing.T) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	if err := enc.Encode(1); err != nil {
+		t.Fatalf("failed to encode: %s", err)
+	}
+	if err := enc.Encode(2); err != nil {
+		t.Fatalf("failed to encode: %s", err)
+	}
+	if actual, expect := buf.String(), "1\n---\n2\n"; actual != expect {
+		t.Errorf("expect:\n%s\nactual\n%s\n", expect, actual)
+	}
+}
+
 func Example_Marshal_Node() {
 	type T struct {
 		Text ast.Node `yaml:"text"`


### PR DESCRIPTION
Fix the behavior as [the comment](https://github.com/goccy/go-yaml/blob/ecececdd257a265811b1646bc8e96b85cc2d2b0d/encode.go#L71-L73).

> If multiple items are encoded to the stream,
> the second and subsequent document will be preceded with a "---" document separator,
> but the first will not.