### PR TITLE
Don't provide stack trace for sentinel errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,17 +1,19 @@
 package yaml
 
 import (
+	"errors"
+
 	"github.com/goccy/go-yaml/ast"
 	"golang.org/x/xerrors"
 )
 
 var (
-	ErrInvalidQuery               = xerrors.New("invalid query")
-	ErrInvalidPath                = xerrors.New("invalid path instance")
-	ErrInvalidPathString          = xerrors.New("invalid path string")
-	ErrNotFoundNode               = xerrors.New("node not found")
-	ErrUnknownCommentPositionType = xerrors.New("unknown comment position type")
-	ErrInvalidCommentMapValue     = xerrors.New("invalid comment map value. it must be not nil value")
+	ErrInvalidQuery               = errors.New("invalid query")
+	ErrInvalidPath                = errors.New("invalid path instance")
+	ErrInvalidPathString          = errors.New("invalid path string")
+	ErrNotFoundNode               = errors.New("node not found")
+	ErrUnknownCommentPositionType = errors.New("unknown comment position type")
+	ErrInvalidCommentMapValue     = errors.New("invalid comment map value. it must be not nil value")
 )
 
 func ErrUnsupportedHeadPositionType(node ast.Node) error {
@@ -20,35 +22,35 @@ func ErrUnsupportedHeadPositionType(node ast.Node) error {
 
 // IsInvalidQueryError whether err is ErrInvalidQuery or not.
 func IsInvalidQueryError(err error) bool {
-	return xerrors.Is(err, ErrInvalidQuery)
+	return errors.Is(err, ErrInvalidQuery)
 }
 
 // IsInvalidPathError whether err is ErrInvalidPath or not.
 func IsInvalidPathError(err error) bool {
-	return xerrors.Is(err, ErrInvalidPath)
+	return errors.Is(err, ErrInvalidPath)
 }
 
 // IsInvalidPathStringError whether err is ErrInvalidPathString or not.
 func IsInvalidPathStringError(err error) bool {
-	return xerrors.Is(err, ErrInvalidPathString)
+	return errors.Is(err, ErrInvalidPathString)
 }
 
 // IsNotFoundNodeError whether err is ErrNotFoundNode or not.
 func IsNotFoundNodeError(err error) bool {
-	return xerrors.Is(err, ErrNotFoundNode)
+	return errors.Is(err, ErrNotFoundNode)
 }
 
 // IsInvalidTokenTypeError whether err is ast.ErrInvalidTokenType or not.
 func IsInvalidTokenTypeError(err error) bool {
-	return xerrors.Is(err, ast.ErrInvalidTokenType)
+	return errors.Is(err, ast.ErrInvalidTokenType)
 }
 
 // IsInvalidAnchorNameError whether err is ast.ErrInvalidAnchorName or not.
 func IsInvalidAnchorNameError(err error) bool {
-	return xerrors.Is(err, ast.ErrInvalidAnchorName)
+	return errors.Is(err, ast.ErrInvalidAnchorName)
 }
 
 // IsInvalidAliasNameError whether err is ast.ErrInvalidAliasName or not.
 func IsInvalidAliasNameError(err error) bool {
-	return xerrors.Is(err, ast.ErrInvalidAliasName)
+	return errors.Is(err, ast.ErrInvalidAliasName)
 }

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -83,7 +84,7 @@ func (e *wrapError) As(target interface{}) bool {
 		}
 		break
 	}
-	return xerrors.As(err, target)
+	return errors.As(err, target)
 }
 
 func (e *wrapError) Unwrap() error {


### PR DESCRIPTION
These values are effectively constants and are documented, so don't pollute the string representation of the error with a constant stack trace. Also use stdlib errors.Is/As rather than xerrors.Is/As where package name collisions allow.

Please take a look.