### PR TITLE
scanner: Find quoted token from context

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -2144,6 +2144,29 @@ b: *a
 			t.Fatal("failed to unmarshal")
 		}
 	})
+	t.Run("quoted map keys", func(t *testing.T) {
+		t.Parallel()
+		yml := `
+a:
+  "b": 2
+  'c': true
+`
+		var v struct {
+			A struct {
+				B int
+				C bool
+			}
+		}
+		if err := yaml.Unmarshal([]byte(yml), &v); err != nil {
+			t.Fatalf("failed to unmarshal %v", err)
+		}
+		if v.A.B != 2 {
+			t.Fatalf("expected a.b to equal 2 but was %d", v.A.B)
+		}
+		if !v.A.C {
+			t.Fatal("expected a.c to be true but was false")
+		}
+	})
 }
 
 type unmarshalablePtrStringContainer struct {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -56,6 +56,10 @@ func TestTokenize(t *testing.T) {
 		"a: 'Hello #comment'\n",
 		"a: 100.5\n",
 		"a: bogus\n",
+		"\"a\": double quoted map key",
+		"'a': single quoted map key",
+		"a: \"double quoted\"\nb: \"value map\"",
+		"a: 'single quoted'\nb: 'value map'",
 	}
 	for _, src := range sources {
 		lexer.Tokenize(src).Dump()
@@ -229,6 +233,60 @@ func TestSingleLineToken_ValueLineColumnPosition(t *testing.T) {
 				11: ",",
 				13: "",
 				15: "]",
+			},
+		},
+		{
+			name: "double quote key",
+			src:  `"a": b`,
+			expect: map[int]string{
+				1: "a",
+				4: ":",
+				6: "b",
+			},
+		},
+		{
+			name: "single quote key",
+			src:  `'a': b`,
+			expect: map[int]string{
+				1: "a",
+				4: ":",
+				6: "b",
+			},
+		},
+		{
+			name: "double quote key and value",
+			src:  `"a": "b"`,
+			expect: map[int]string{
+				1: "a",
+				4: ":",
+				6: "b",
+			},
+		},
+		{
+			name: "single quote key and value",
+			src:  `'a': 'b'`,
+			expect: map[int]string{
+				1: "a",
+				4: ":",
+				6: "b",
+			},
+		},
+		{
+			name: "double quote key, single quote value",
+			src:  `"a": 'b'`,
+			expect: map[int]string{
+				1: "a",
+				4: ":",
+				6: "b",
+			},
+		},
+		{
+			name: "single quote key, double quote value",
+			src:  `'a': "b"`,
+			expect: map[int]string{
+				1: "a",
+				4: ":",
+				6: "b",
 			},
 		},
 	}
@@ -429,6 +487,59 @@ foo2: 'bar2'`,
 					line:   7,
 					column: 7,
 					value:  "bar2",
+				},
+			},
+		},
+		{
+			name: "single and double quote map keys",
+			src: `"a": test
+'b': 1
+c: true`,
+			expect: []testToken{
+				{
+					line:   1,
+					column: 1,
+					value:  "a",
+				},
+				{
+					line:   1,
+					column: 4,
+					value:  ":",
+				},
+				{
+					line:   1,
+					column: 6,
+					value:  "test",
+				},
+				{
+					line:   2,
+					column: 1,
+					value:  "b",
+				},
+				{
+					line:   2,
+					column: 4,
+					value:  ":",
+				},
+				{
+					line:   2,
+					column: 6,
+					value:  "1",
+				},
+				{
+					line:   3,
+					column: 1,
+					value:  "c",
+				},
+				{
+					line:   3,
+					column: 2,
+					value:  ":",
+				},
+				{
+					line:   3,
+					column: 4,
+					value:  "true",
 				},
 			},
 		},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -80,6 +80,8 @@ func TestParser(t *testing.T) {
   ? !!str "implicit" : !!str "entry",
   ? !!null "" : !!null "",
 }`,
+		"\"a\": a\n\"b\": b",
+		"'a': a\n'b': b",
 	}
 	for _, src := range sources {
 		if _, err := parser.Parse(lexer.Tokenize(src), 0); err != nil {
@@ -562,6 +564,22 @@ b: c
 			`
 - key1: val
   key2: ( foo + bar )
+`,
+		},
+		{
+			`
+"a": b
+'c': d
+"e": "f"
+g: "h"
+i: 'j'
+`,
+			`
+"a": b
+'c': d
+"e": "f"
+g: "h"
+i: 'j'
 `,
 		},
 	}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -249,6 +249,7 @@ func (s *Scanner) scanSingleQuote(ctx *Context) (tk *token.Token, pos int) {
 			value = append(value, c)
 			ctx.addOriginBuf(c)
 			idx++
+			s.progressColumn(ctx, 1)
 			continue
 		}
 		s.progressColumn(ctx, 1)


### PR DESCRIPTION
Closes #301 

To resolve an issue with quoted map keys not correctly parsing, this PR changes how it progresses after scanning a quote token.

The old behaviour was:
1. scanner reaches a :
2. pull the characters out of the current scan context buffer and turn it into the map key token
3. set the previous indent column to the beginning of the buffer So next time it gets to another key in the map, it'll check whether the indent was the same.

When scanning a quote:
1. Scan from the beginning to the end of the quote sequence
2. Add a token, send back to the lexer, and reset the scan context In this scenario, it reaches the :, but nothing is in the scan context buffer because it just went ahead and added the quote token. The previous indent column doesn't get reset, so when it gets to the next map key it thinks the indent increased, which is invalid yaml.

The new behaviour is essentially to not reset the context after scanning a quote, and when reaching a : check the context tokens, and if it's a quote set the previous indent column to that