### PR TITLE
ast: append new line at the end of file

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -566,6 +566,10 @@ func (f *File) String() string {
 	for _, doc := range f.Docs {
 		docs = append(docs, doc.String())
 	}
+	if len(docs) > 0 {
+		// append new line at the end of file
+		docs = append(docs, "\n")
+	}
 	return strings.Join(docs, "\n")
 }
 

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -567,10 +567,10 @@ func (f *File) String() string {
 		docs = append(docs, doc.String())
 	}
 	if len(docs) > 0 {
-		// append new line at the end of file
-		docs = append(docs, "\n")
+		return strings.Join(docs, "\n") + "\n"
+	} else {
+		return ""
 	}
-	return strings.Join(docs, "\n")
 }
 
 // DocumentNode type of Document

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -595,7 +595,7 @@ i: 'j'
 			for _, doc := range f.Docs {
 				ast.Walk(&v, doc.Body)
 			}
-			expect := fmt.Sprintf("\n%+v\n", f)
+			expect := fmt.Sprintf("\n%+v", f)
 			if test.expect != expect {
 				tokens.Dump()
 				t.Fatalf("unexpected output: [%s] != [%s]", test.expect, expect)
@@ -614,7 +614,7 @@ func TestNewLineChar(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-		actual := fmt.Sprintf("%v\n", ast)
+		actual := fmt.Sprintf("%v", ast)
 		expect := `a: "a"
 b: 1
 `
@@ -800,7 +800,7 @@ foo: > # comment
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
-			got := "\n" + f.String() + "\n"
+			got := "\n" + f.String()
 			if test.yaml != got {
 				t.Fatalf("expected:%s\ngot:%s", test.yaml, got)
 			}

--- a/path_test.go
+++ b/path_test.go
@@ -343,7 +343,7 @@ a:
 				if err := path.MergeFromReader(file, strings.NewReader(test.src)); err != nil {
 					t.Fatalf("%+v", err)
 				}
-				actual := "\n" + file.String() + "\n"
+				actual := "\n" + file.String()
 				if test.expected != actual {
 					t.Fatalf("expected: %q. but got %q", test.expected, actual)
 				}
@@ -360,7 +360,7 @@ a:
 				if err := path.MergeFromFile(file, src); err != nil {
 					t.Fatalf("%+v", err)
 				}
-				actual := "\n" + file.String() + "\n"
+				actual := "\n" + file.String()
 				if test.expected != actual {
 					t.Fatalf("expected: %q. but got %q", test.expected, actual)
 				}
@@ -380,7 +380,7 @@ a:
 				if err := path.MergeFromNode(file, src.Docs[0]); err != nil {
 					t.Fatalf("%+v", err)
 				}
-				actual := "\n" + file.String() + "\n"
+				actual := "\n" + file.String()
 				if test.expected != actual {
 					t.Fatalf("expected: %q. but got %q", test.expected, actual)
 				}
@@ -525,7 +525,7 @@ building:
 				if err := path.ReplaceWithReader(file, strings.NewReader(test.src)); err != nil {
 					t.Fatalf("%+v", err)
 				}
-				actual := "\n" + file.String() + "\n"
+				actual := "\n" + file.String()
 				if test.expected != actual {
 					t.Fatalf("expected: %q. but got %q", test.expected, actual)
 				}
@@ -542,7 +542,7 @@ building:
 				if err := path.ReplaceWithFile(file, src); err != nil {
 					t.Fatalf("%+v", err)
 				}
-				actual := "\n" + file.String() + "\n"
+				actual := "\n" + file.String()
 				if test.expected != actual {
 					t.Fatalf("expected: %q. but got %q", test.expected, actual)
 				}
@@ -562,7 +562,7 @@ building:
 				if err := path.ReplaceWithNode(file, src.Docs[0]); err != nil {
 					t.Fatalf("%+v", err)
 				}
-				actual := "\n" + file.String() + "\n"
+				actual := "\n" + file.String()
 				if test.expected != actual {
 					t.Fatalf("expected: %q. but got %q", test.expected, actual)
 				}


### PR DESCRIPTION
According to the POSIX Stndard, The definition of a LINE is,
> A sequence of zero or more non- characters plus a terminating character.

https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline

I think there should be end with `\n` on generated yaml file.
