### PR TITLE
scanner: fix position calculation for literal, folded and raw folded strings

### DIFF
--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -543,6 +543,49 @@ c: true`,
 				},
 			},
 		},
+		{
+			name: "issue326",
+			src: `a: |
+  Text
+b: 1`,
+			expect: []testToken{
+				{
+					line:   1,
+					column: 1,
+					value:  "a",
+				},
+				{
+					line:   1,
+					column: 2,
+					value:  ":",
+				},
+				{
+					line:   1,
+					column: 4,
+					value:  "|",
+				},
+				{
+					line:   2,
+					column: 3,
+					value:  "Text\n",
+				},
+				{
+					line:   3,
+					column: 1,
+					value:  "b",
+				},
+				{
+					line:   3,
+					column: 2,
+					value:  ":",
+				},
+				{
+					line:   3,
+					column: 4,
+					value:  "1",
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -61,13 +61,25 @@ func (s *Scanner) bufferedToken(ctx *Context) *token.Token {
 		s.savedPos = nil
 		return tk
 	}
-	size := len(ctx.buf)
+	line := s.line
+	column := s.column - len(ctx.buf)
+	level := s.indentLevel
+	if ctx.isSaveIndentMode() {
+		line -= s.newLineCount(ctx.buf)
+		column = strings.Index(string(ctx.obuf), string(ctx.buf)) + 1
+		// Since we are in a literal, folded or raw folded
+		// we can use the indent level from the last token.
+		last := ctx.lastToken()
+		if last != nil { // The last token should never be nil here.
+			level = last.Position.IndentLevel + 1
+		}
+	}
 	return ctx.bufferedToken(&token.Position{
-		Line:        s.line,
-		Column:      s.column - size,
-		Offset:      s.offset - size,
+		Line:        line,
+		Column:      column,
+		Offset:      s.offset - len(ctx.buf),
 		IndentNum:   s.indentNum,
-		IndentLevel: s.indentLevel,
+		IndentLevel: level,
 	})
 }
 


### PR DESCRIPTION
The approach to calculating the column is not ideal from an allocations perpective, but is similar to other calculations in the code base that do a temporary `[]rune` → `string` conversion. I would prefer to retain an offset field instead, but that is a more invasive change.

The setting of `token.Position.IndentNum` is left as is since it's not clear to me what that is there for; the field is never read in the code base and so is apparently not used internally (removal does not affect tests, though external client code may be using it for something).

Fixes #326.

Please take a look.