### PR TITLE
Support strings starting with @

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -623,7 +623,7 @@ func IsNeedQuoted(value string) bool {
 	}
 	first := value[0]
 	switch first {
-	case '*', '&', '[', '{', '}', ']', ',', '!', '|', '>', '%', '\'', '"':
+	case '*', '&', '[', '{', '}', ']', ',', '!', '|', '>', '%', '\'', '"', '@':
 		return true
 	}
 	last := value[len(value)-1]

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -117,6 +117,7 @@ func TestIsNeedQuoted(t *testing.T) {
 		"off",
 		"Off",
 		"OFF",
+		"@test",
 	}
 	for i, test := range needQuotedTests {
 		if !token.IsNeedQuoted(test) {


### PR DESCRIPTION
## 📟 Context

It seems that I ran into an unsupported situation when generating yaml with strings starting with `@`.

Golang playground example that shows the output: https://play.golang.com/p/ANKYK0xUXF8.

From the example above, we get the following yaml:

```yaml
k: @foobar
```

which is not valid. See [yaml linter](https://www.yamllint.com/):

![Screenshot 2023-01-16 at 13 23 53](https://user-images.githubusercontent.com/337347/212677582-6c898c3f-bbd8-4315-ade0-6a293e3460de.png)

## 🤔 What does this PR do?

* Update `token.go` so that strings starting with `@` are quoted.
* Update the related test.

## ⚙️ How to test this locally?

1. Use the code from the playground example: https://play.golang.com/p/ANKYK0xUXF8
1. Using this PR, we get the following:
    ```yaml
    k: "@foobar"
    ```
    
That's a valid YAML 🎉 
