### PR TITLE
Fix handle double quoted string

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -767,7 +767,7 @@ func TestDecoder(t *testing.T) {
 		},
 		{
 			"a: \"\\0\"\n",
-			map[string]string{"a": "\\0"},
+			map[string]string{"a": "\x00"},
 		},
 		{
 			"b: 2\na: 1\nd: 4\nc: 3\nsub:\n  e: 5\n",


### PR DESCRIPTION
## Background

This `Example 7.5 Double Quoted Line Breaks` case is not working properly. Some related cases as well.
https://yaml.org/spec/1.2.2/#example-double-quoted-line-breaks

I'd like to handle correctly this behavior.

## What are these changes

- Edited on scanner/scanner.go
    - Added utility function: `isWhiteChar`
        - Confirm the char is space or tab.
    - Added utility function: `isOnlyWhiteToLineEnds`
        - Confirm only white between current index - newline.
    - Added new function: `scanNextEmptyLines`
        - This function is aimed to scan the next empty lines and skip do `scan`.
    - Added `docStartLine` field in Scanner.
        - I'm not sure `a: |\n  Text\n` seems not worked properly. It will be used to fix this issue with `scanLiteral` changes.
    - Changes in `scanDoubleQuote`
        - When a newline is found, skip the next empty lines. To ignore new line if next empty lines exist.
        - When white is found and it continues to a newline, ignore it.
        - When escape char `\`is found, ignore the next char.
- Also added some more testcases.