### PR TITLE
Escape strings containing font glyphs (Nerd Font compatibility)

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -845,6 +845,14 @@ func TestDecoder(t *testing.T) {
 			map[string]string{"v": "hello\n...\nworld\n"},
 		},
 		{
+			"v: >\n  hello\n  ...\n  world\n",
+			map[string]string{"v": "hello ... world"},
+		},
+		{
+			"v: \"hello\n  ...\n  world\n\"",
+			map[string]string{"v": "hello ... world "},
+		},
+		{
 			"a: !!binary gIGC\n",
 			map[string]string{"a": "\x80\x81\x82"},
 		},
@@ -2654,8 +2662,8 @@ func TestDecoder_LiteralWithNewLine(t *testing.T) {
 
 func TestDecoder_TabCharacterAtRight(t *testing.T) {
 	yml := `
-- a: [2 , 2] 			
-  b: [2 , 2] 			
+- a: [2 , 2]
+  b: [2 , 2]
   c: [2 , 2]`
 	var v []map[string][]int
 	if err := yaml.Unmarshal([]byte(yml), &v); err != nil {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -141,7 +141,7 @@ func (s *Scanner) newLineCount(src []rune) int {
 }
 
 func (s *Scanner) updateIndentState(ctx *Context) {
-	indentNumBasedIndentState := s.indentState
+	var indentNumBasedIndentState IndentState
 	if s.prevIndentNum < s.indentNum {
 		s.indentLevel = s.prevIndentLevel + 1
 		indentNumBasedIndentState = IndentStateUp

--- a/token/token.go
+++ b/token/token.go
@@ -612,7 +612,7 @@ func looksLikeTimeValue(value string) bool {
 
 // IsNeedQuoted whether need quote for passed string or not
 func IsNeedQuoted(value string) bool {
-	if value == "" {
+	if value == "" || value == "~" {
 		return true
 	}
 	if _, exists := reservedEncKeywordMap[value]; exists {


### PR DESCRIPTION
This fixes an issue with Nerd Font glyphs (and others, but this is my use-case) not being recognised resulting in a non-quoted string, which in YAML makes them literal text rather than icons. This breaks config exports and migrations for oh-my-posh.

Example:

```go
map[string]string{"v": "\ue0b6"},
```

Is encoded to YAML as:

```yaml
v: \ue0b6
```

But that should be:

```
v: "\ue0b6"
```

The `isEmoticon` function is the same as the one we use for oh-my-posh which has worked without issues so far.