### PR TITLE
Address goccy/go-yaml#345

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -136,6 +136,7 @@ func (d *Decoder) setToMapValue(node ast.Node, m map[string]interface{}) {
 }
 
 func (d *Decoder) setToOrderedMapValue(node ast.Node, m *MapSlice) {
+	d.setPathToCommentMap(node)
 	switch n := node.(type) {
 	case *ast.MappingValueNode:
 		if n.Key.Type() == ast.MergeKeyType {


### PR DESCRIPTION
OrderedMap values aren't recording their comments like normal maps. Reproduced using the example in the linked issue, copied below:

```go
package main

import (
	"bytes"
	"fmt"
	"io"

	"github.com/goccy/go-yaml"
)

var contents = []byte(`
top:
  # This comment is captured
  first: true
  # But not this one
  second:
    # But this one is
    first: true
    # But not this one
    second: true
    # Neither this
    third: true
`)

func main() {
	cm := yaml.CommentMap{}
	dec := yaml.NewDecoder(bytes.NewReader(contents), yaml.UseOrderedMap(), yaml.CommentToMap(cm))

	for {
		var mslice yaml.MapSlice
		err := dec.Decode(&mslice)
		if err == io.EOF {
			break
		}

		if err != nil {
			panic(err)
		}
	}

	for _, comment := range cm {
		fmt.Println(comment.Texts)
	}
}
```

Before this change, the bug exists. With this change, it's fixed.