### PR TITLE
token: escape number with exponent without dot

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -519,14 +519,14 @@ func getNumberStat(str string) *numStat {
 				// binary number
 				continue
 			}
-			if (c == 'e' || c == 'E') && dotFound {
+			if (c == 'e' || c == 'E') && !isExponent && ((isNegative && idx > 2) || (!isNegative && idx > 1)) {
 				// exponent
 				isExponent = true
 				continue
 			}
 		case '.':
-			if dotFound {
-				// multiple dot
+			if dotFound || isExponent {
+				// multiple dots or dot used in exponent
 				return stat
 			}
 			dotFound = true
@@ -546,7 +546,7 @@ func getNumberStat(str string) *numStat {
 	}
 	stat.isNum = true
 	switch {
-	case dotFound:
+	case dotFound || isExponent:
 		stat.typ = numTypeFloat
 	case strings.HasPrefix(str, "0b") || strings.HasPrefix(str, "-0b"):
 		stat.typ = numTypeBinary

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -80,7 +80,10 @@ func TestIsNeedQuoted(t *testing.T) {
 	needQuotedTests := []string{
 		"",
 		"true",
+		"1",
 		"1.234",
+		"44987e08",
+		"-44987e08",
 		"1:1",
 		"hoge # comment",
 		"\\0",
@@ -109,6 +112,11 @@ func TestIsNeedQuoted(t *testing.T) {
 	}
 	notNeedQuotedTests := []string{
 		"Hello World",
+		"e",
+		"ee",
+		"eee",
+		"ae34",
+		"123e4.5",
 	}
 	for i, test := range notNeedQuotedTests {
 		if token.IsNeedQuoted(test) {


### PR DESCRIPTION
A string like "44987e08" needs to be escaped, otherwise it would be parsed as float with exponent.