### PR TITLE
Fix recursive anchor/alias stack overflow (#353)

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1007,7 +1007,7 @@ func (d *Decoder) keyToNodeMap(node ast.Node, ignoreMergeKey bool, getKeyOrValue
 		} else {
 			key, ok := d.nodeToValue(keyNode).(string)
 			if !ok {
-				return nil, errors.Wrapf(err, "failed to decode map key")
+				return nil, xerrors.New("failed to decode map key")
 			}
 			if err := d.validateDuplicateKey(keyMap, key, keyNode); err != nil {
 				return nil, errors.Wrapf(err, "invalid struct key")

--- a/decode_test.go
+++ b/decode_test.go
@@ -2715,6 +2715,36 @@ func TestDecoder_DecodeWithNode(t *testing.T) {
 	})
 }
 
+func TestDecoder_RecursiveAlias(t *testing.T) {
+	type Key struct {
+		Key *Key
+	}
+
+	var v struct {
+		A *Key
+		B *Key
+	}
+
+	const src = `
+a: &anchor
+  key: *anchor
+b: *anchor
+`
+
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&v); err != nil {
+		t.Fatalf(`parsing should succeed: %s`, err)
+	}
+
+	if v.A != v.A.Key || v.B != v.A || v.B.Key != v.A {
+		t.Errorf("expected recursive aliases to be the same: A: %p, A.Key: %p, B: %p, B.Key: %p",
+			v.A,
+			v.A.Key,
+			v.B,
+			v.B.Key,
+		)
+	}
+}
+
 func TestRoundtripAnchorAlias(t *testing.T) {
 	t.Run("irreversible", func(t *testing.T) {
 		type foo struct {


### PR DESCRIPTION
As stated in Issue #353, the following yaml causes a stack overflow:

```yaml
key1: &anchor
  subkey: *anchor
key2: *anchor
```

Having a self-referential anchor that is also referenced outside the anchor causes the parser (particularly `nodeToValue`) to recurse infinitely. I'm honestly not sure why a simpler self-referential anchor parses successfully, e.g.

```yaml
key1: &anchor
  subkey: *anchor
```

In any case, this can be fixed simply by only visiting (e.g. calling `nodeToValue` on) alias nodes once. Since the only really useful type for self-referential aliases is a pointer to something, this works out. The first call will marshal onto the type, and the rest of the references will be resolved to the same alias pointer.

This PR does the following:

- Adds a test case for the failing yaml
- Adds the above logic by adding an `aliasSet` set field on Decoder and extra checks in `nodeToValue`
- Fixes a wrapped nil error that made this issue even harder to debug (`errors.Wrapf(nil, ...)` prints as "\<nil\>" for most formatting flags in fmt.Print, despite the error itself not actually being equal to  `nil`)