### PR TITLE
Don't trim all space characters in SequenceNode.blockStyleString

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1570,8 +1570,9 @@ func (n *SequenceNode) blockStyleString() string {
 		diffLength := len(splittedValues[0]) - len(trimmedFirstValue)
 		if len(splittedValues) > 1 && value.Type() == StringType || value.Type() == LiteralType {
 			// If multi-line string, the space characters for indent have already been added, so delete them.
+			prefix := space + "  "
 			for i := 1; i < len(splittedValues); i++ {
-				splittedValues[i] = strings.TrimLeft(splittedValues[i], " ")
+				splittedValues[i] = strings.TrimPrefix(splittedValues[i], prefix)
 			}
 		}
 		newValues := []string{trimmedFirstValue}

--- a/encode_test.go
+++ b/encode_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/goccy/go-yaml/parser"
 	"math"
 	"reflect"
 	"strconv"
@@ -1397,6 +1398,24 @@ func Example_MarshalYAML() {
 	// b: 100
 	//
 	// field: 13
+}
+
+func TestIssue356(t *testing.T) {
+	in := `args:
+  - |
+    key:
+      nest1: something
+      nest2:
+        nest2a: b
+`
+	f, err := parser.ParseBytes([]byte(in), 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := f.String()
+	if in != got {
+		t.Fatalf("failed to encode.\nexpected:\n%s\nbut got:\n%s\n", in, got)
+	}
 }
 
 func TestMarshalIndentWithMultipleText(t *testing.T) {


### PR DESCRIPTION
This fixes https://github.com/goccy/go-yaml/issues/356. The code would have removed more spaces than it added.

A better solution long-term would probably be to add a specialized method to StringNode to not add the prefix in the first place.