### PR TITLE
Fix quoted comments

### DIFF
--- a/parser/context.go
+++ b/parser/context.go
@@ -13,7 +13,6 @@ type context struct {
 	idx    int
 	size   int
 	tokens token.Tokens
-	mode   Mode
 	path   string
 }
 
@@ -56,7 +55,6 @@ func (c *context) copy() *context {
 		idx:    c.idx,
 		size:   c.size,
 		tokens: append(token.Tokens{}, c.tokens...),
-		mode:   c.mode,
 		path:   c.path,
 	}
 }
@@ -145,10 +143,6 @@ func (c *context) afterNextNotCommentToken() *token.Token {
 	return nil
 }
 
-func (c *context) enabledComment() bool {
-	return c.mode&ParseComments != 0
-}
-
 func (c *context) isCurrentCommentToken() bool {
 	tk := c.currentToken()
 	if tk == nil {
@@ -193,7 +187,6 @@ func newContext(tokens token.Tokens, mode Mode) *context {
 		idx:    0,
 		size:   len(filteredTokens),
 		tokens: token.Tokens(filteredTokens),
-		mode:   mode,
 		path:   "$",
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -824,6 +824,8 @@ a: # commentA
   i: fuga # commentI
 j: piyo # commentJ
 k.l.m.n: moge # commentKLMN
+o#p: hogera # commentOP
+q#.r: hogehoge # commentQR
 `
 	f, err := parser.ParseBytes([]byte(yml), parser.ParseComments)
 	if err != nil {
@@ -854,6 +856,8 @@ k.l.m.n: moge # commentKLMN
 		"$.a.i",
 		"$.j",
 		"$.'k.l.m.n'",
+		"$.o#p",
+		"$.'q#.r'",
 	}
 	if !reflect.DeepEqual(expectedPaths, commentPaths) {
 		t.Fatalf("failed to get YAMLPath to the comment node:\nexpected[%s]\ngot     [%s]", expectedPaths, commentPaths)

--- a/path.go
+++ b/path.go
@@ -501,7 +501,7 @@ func newSelectorNode(selector string) *selectorNode {
 
 func (n *selectorNode) filter(node ast.Node) (ast.Node, error) {
 	selector := n.selector
-	if len(selector) > 0 && selector[0] == '\'' && selector[len(selector)-1] == '\'' {
+	if len(selector) > 1 && selector[0] == '\'' && selector[len(selector)-1] == '\'' {
 		selector = selector[1 : len(selector)-1]
 	}
 	switch node.Type() {
@@ -517,7 +517,7 @@ func (n *selectorNode) filter(node ast.Node) (ast.Node, error) {
 						return nil, errors.Wrapf(err, "failed to unquote")
 					}
 				case '\'':
-					if key[len(key)-1] == '\'' {
+					if len(key) > 1 && key[len(key)-1] == '\'' {
 						key = key[1 : len(key)-1]
 					}
 				}

--- a/path.go
+++ b/path.go
@@ -587,7 +587,9 @@ func (n *selectorNode) replace(node ast.Node, target ast.Node) error {
 }
 
 func (n *selectorNode) String() string {
-	s := fmt.Sprintf(".%s", (*PathBuilder).normalizeSelectorName(nil, n.selector))
+	var builder PathBuilder
+	selector := builder.normalizeSelectorName(n.selector)
+	s := fmt.Sprintf(".%s", selector)
 	if n.child != nil {
 		s += n.child.String()
 	}

--- a/path.go
+++ b/path.go
@@ -387,26 +387,12 @@ func (b *PathBuilder) Recursive(selector string) *PathBuilder {
 	return b
 }
 
-func containsReservedPathCharacters(path string) bool {
-	if strings.Contains(path, ".") {
-		return true
-	}
-	if strings.Contains(path, "*") {
-		return true
-	}
-	return false
-}
-
-func enclosedSingleQuote(name string) bool {
-	return strings.HasPrefix(name, "'") && strings.HasSuffix(name, "'")
-}
-
 func normalizeSelectorName(name string) string {
-	if enclosedSingleQuote(name) {
+	if len(name) > 1 && name[0] == '\'' && name[len(name)-1] == '\'' {
 		// already escaped name
 		return name
 	}
-	if containsReservedPathCharacters(name) {
+	if strings.ContainsAny(name, `.*`) {
 		escapedName := strings.ReplaceAll(name, `'`, `\'`)
 		return "'" + escapedName + "'"
 	}

--- a/path.go
+++ b/path.go
@@ -99,10 +99,6 @@ func parsePathDot(b *PathBuilder, buf []rune, cursor int) (*PathBuilder, []rune,
 	if cursor < length && buf[cursor] == '\'' {
 		return parseQuotedKey(b, buf, cursor)
 	}
-	// if started with double quote, unquote the key
-	if cursor < length && buf[cursor] == '"' {
-		return parseDoubleQuotedKey(b, buf, cursor)
-	}
 	for ; cursor < length; cursor++ {
 		c := buf[cursor]
 		switch c {
@@ -158,20 +154,6 @@ end:
 		}
 	}
 	return b.child(string(selector)), buf, cursor, nil
-}
-
-func parseDoubleQuotedKey(b *PathBuilder, buf []rune, cursor int) (*PathBuilder, []rune, int, error) {
-	start := cursor
-	key, err := strconv.QuotedPrefix(string(buf[start:]))
-	if err != nil {
-		return nil, nil, 0, errors.Wrapf(ErrInvalidPathString, "failed to parse double quoted key")
-	}
-	cursor += len(key)
-	key, err = strconv.Unquote(key)
-	if err != nil {
-		return nil, nil, 0, errors.Wrapf(ErrInvalidPathString, "failed to parse double quoted key")
-	}
-	return b.child(key), buf, cursor, nil
 }
 
 func parsePathIndex(b *PathBuilder, buf []rune, cursor int) (*PathBuilder, []rune, int, error) {

--- a/path.go
+++ b/path.go
@@ -99,10 +99,10 @@ func parsePathDot(b *PathBuilder, buf []rune, cursor int) (*PathBuilder, []rune,
 	if cursor < length && buf[cursor] == '\'' {
 		return parseQuotedKey(b, buf, cursor)
 	}
-	//// if started with double quote, unquote the key
-	//if cursor < length && buf[cursor] == '"' {
-	//	return parseDoubleQuotedKey(b, buf, cursor)
-	//}
+	// if started with double quote, unquote the key
+	if cursor < length && buf[cursor] == '"' {
+		return parseDoubleQuotedKey(b, buf, cursor)
+	}
 	for ; cursor < length; cursor++ {
 		c := buf[cursor]
 		switch c {

--- a/path.go
+++ b/path.go
@@ -501,7 +501,7 @@ func newSelectorNode(selector string) *selectorNode {
 
 func (n *selectorNode) filter(node ast.Node) (ast.Node, error) {
 	selector := n.selector
-	if len(selector) > 0 && selector[0] == '\'' {
+	if len(selector) > 0 && selector[0] == '\'' && selector[len(selector)-1] == '\'' {
 		selector = selector[1 : len(selector)-1]
 	}
 	switch node.Type() {
@@ -517,7 +517,9 @@ func (n *selectorNode) filter(node ast.Node) (ast.Node, error) {
 						return nil, errors.Wrapf(err, "failed to unquote")
 					}
 				case '\'':
-					key = key[1 : len(key)-1]
+					if key[len(key)-1] == '\'' {
+						key = key[1 : len(key)-1]
+					}
 				}
 			}
 			if key == selector {

--- a/path_test.go
+++ b/path_test.go
@@ -100,10 +100,15 @@ store:
 			expected: float64(19.95),
 		},
 		{
-			name:     `$.store.'bicycle*unicycle'.price`,
+			name:     `$.store.'bicycle*unicycle.price`,
 			path:     builder().Root().Child("store").Child(`bicycle*unicycle`).Child("price").Build(),
 			expected: float64(20.25),
 		},
+		//{
+		//	name:     `$.store.'bicycle*unicycle.price`,
+		//	path:     builder().Root().Child("store").Child(`bicycle*unicycle`).Child("price").Build(),
+		//	expected: float64(20.25),
+		//},
 	}
 	t.Run("PathString", func(t *testing.T) {
 		for _, test := range tests {

--- a/path_test.go
+++ b/path_test.go
@@ -61,6 +61,8 @@ store:
   bicycle:
     color: red
     price: 19.95
+  bicycle*unicycle:
+    price: 20.25
 `
 	tests := []struct {
 		name     string
@@ -97,6 +99,11 @@ store:
 			path:     builder().Root().Child("store").Child("bicycle").Child("price").Build(),
 			expected: float64(19.95),
 		},
+		{
+			name:     `$.store.'bicycle*unicycle'.price`,
+			path:     builder().Root().Child("store").Child(`bicycle*unicycle`).Child("price").Build(),
+			expected: float64(20.25),
+		},
 	}
 	t.Run("PathString", func(t *testing.T) {
 		for _, test := range tests {
@@ -105,8 +112,9 @@ store:
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
-				if test.name != path.String() {
-					t.Fatalf("expected %s but actual %s", test.name, path.String())
+				got := path.String()
+				if test.name != got {
+					t.Fatalf("expected %s but actual %s", test.name, got)
 				}
 			})
 		}

--- a/path_test.go
+++ b/path_test.go
@@ -112,9 +112,8 @@ store:
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
-				got := path.String()
-				if test.name != got {
-					t.Fatalf("expected %s but actual %s", test.name, got)
+				if test.name != path.String() {
+					t.Fatalf("expected %s but actual %s", test.name, path.String())
 				}
 			})
 		}

--- a/path_test.go
+++ b/path_test.go
@@ -100,15 +100,10 @@ store:
 			expected: float64(19.95),
 		},
 		{
-			name:     `$.store.'bicycle*unicycle.price`,
+			name:     `$.store.'bicycle*unicycle'.price`,
 			path:     builder().Root().Child("store").Child(`bicycle*unicycle`).Child("price").Build(),
 			expected: float64(20.25),
 		},
-		//{
-		//	name:     `$.store.'bicycle*unicycle.price`,
-		//	path:     builder().Root().Child("store").Child(`bicycle*unicycle`).Child("price").Build(),
-		//	expected: float64(20.25),
-		//},
 	}
 	t.Run("PathString", func(t *testing.T) {
 		for _, test := range tests {


### PR DESCRIPTION
fixes #369 

This resolves the quoted comments issue by updating the path filter account for quoted selectors.

Slightly related to this, I found that `Path.String()` wasn't normalizing its output. I had to remove the `*PathBuilder` receiver from `normalizeSelectorName()` to make this work.

The changes to `context.go` are not related to the rest of this PR. While tracing this I noticed that `context.mode` isn't used, so I removed it.