### PR TITLE
Handle `\r` in a double-quoted string the same as `\n`

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -425,6 +425,14 @@ func TestDecoder(t *testing.T) {
 			`"1": "a\x2Fb\u002Fc\U0000002Fd"`,
 			map[interface{}]interface{}{"1": `a/b/c/d`},
 		},
+		{
+			"'1': \"2\\n3\"",
+			map[interface{}]interface{}{"1": "2\n3"},
+		},
+		{
+			"'1': \"2\\r\\n3\"",
+			map[interface{}]interface{}{"1": "2\r\n3"},
+		},
 
 		{
 			"a: -b_c",

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -339,6 +339,11 @@ func (s *Scanner) scanDoubleQuote(ctx *Context) (tk *token.Token, pos int) {
 					value = append(value, '\n')
 					idx++
 					continue
+				case 'r':
+					ctx.addOriginBuf(nextChar)
+					value = append(value, '\r')
+					idx++
+					continue
 				case 'v':
 					ctx.addOriginBuf(nextChar)
 					value = append(value, '\v')


### PR DESCRIPTION
Fix https://github.com/goccy/go-yaml/issues/371

If https://github.com/goccy/go-yaml/issues/371 is not the intended behavior, please consider merging this PR.