### PR TITLE
fix: skip encoding an inline field if it is null

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -823,6 +823,10 @@ func (e *Encoder) encodeStruct(ctx context.Context, value reflect.Value, column 
 			}
 			mapNode, ok := value.(ast.MapNode)
 			if !ok {
+				// if an inline field is null, skip encoding it
+				if _, ok := value.(*ast.NullNode); ok {
+					continue
+				}
 				return nil, xerrors.Errorf("inline value is must be map or struct type")
 			}
 			mapIter := mapNode.MapRange()

--- a/encode_test.go
+++ b/encode_test.go
@@ -980,6 +980,30 @@ c: true
 	}
 }
 
+func TestEncoder_InlineNil(t *testing.T) {
+	type base struct {
+		A int
+		B string
+	}
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	if err := enc.Encode(struct {
+		*base `yaml:",inline"`
+		C     bool
+	}{
+		C: true,
+	}); err != nil {
+		t.Fatalf("%+v", err)
+	}
+	expect := `
+c: true
+`
+	actual := "\n" + buf.String()
+	if expect != actual {
+		t.Fatalf("inline marshal error: expect=[%s] actual=[%s]", expect, actual)
+	}
+}
+
 func TestEncoder_Flow(t *testing.T) {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf, yaml.Flow(true))


### PR DESCRIPTION
The current implementation returns an error if an inline field is null. This PR makes skipping encoding null inline fields.

This behavior is the same as `encoding/json`.

```go
b, err := json.Marshal(struct {
	*base `yaml:",inline"`
	C     bool
}{
	C: true,
})
if err != nil {
	panic(err)
}
fmt.Println(string(b))
```
=> `{"C":true}`