### PR TITLE
bump actions/checkout v4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: test
       run: |
         make test
@@ -38,7 +38,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: test
       run: |
         make simple-test
@@ -52,7 +52,7 @@ jobs:
         with:
           go-version: "1.20"
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: build
         run: |
           make ycat/build
@@ -69,7 +69,7 @@ jobs:
         with:
           go-version: "1.20"
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: measure coverage
         run: |
           make cover


### PR DESCRIPTION
https://github.com/actions/checkout/releases/tag/v4.0.0 has been released.
actions/checkout v3 uses node.js 16 that ends its life.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification