### PR TITLE
add Go 1.21 to the build matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        go-version: [ "1.18", "1.19", "1.20" ]
+        go-version: [ "1.18", "1.19", "1.20", "1.21" ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: setup Go ${{ matrix.go-version }}
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "windows-latest" ]
-        go-version: [ "1.18", "1.19", "1.20" ]
+        go-version: [ "1.18", "1.19", "1.20", "1.21" ]
     runs-on: ${{ matrix.os }}
     env:
       GOARCH: "386"
@@ -50,7 +50,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: checkout
         uses: actions/checkout@v3
       - name: build
@@ -67,7 +67,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: checkout
         uses: actions/checkout@v3
       - name: measure coverage

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        go-version: [ "1.18", "1.19", "1.20", "1.21" ]
+        go-version: [ "1.19", "1.20", "1.21" ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: setup Go ${{ matrix.go-version }}
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "windows-latest" ]
-        go-version: [ "1.18", "1.19", "1.20", "1.21" ]
+        go-version: [ "1.19", "1.20", "1.21" ]
     runs-on: ${{ matrix.os }}
     env:
       GOARCH: "386"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goccy/go-yaml
 
-go 1.18
+go 1.19
 
 require (
 	github.com/fatih/color v1.10.0


### PR DESCRIPTION
Go 1.21 has been released.
I added Go 1.21 to the build matrix.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification