### PR TITLE
bump actions/setup-go v4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,12 +13,12 @@ jobs:
         go-version: [ "1.18", "1.19", "1.20" ]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: setup Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
     - name: checkout
       uses: actions/checkout@v3
+    - name: setup Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
     - name: test
       run: |
         make test
@@ -33,12 +33,12 @@ jobs:
     env:
       GOARCH: "386"
     steps:
-    - name: setup Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
     - name: checkout
       uses: actions/checkout@v3
+    - name: setup Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
     - name: test
       run: |
         make simple-test
@@ -47,12 +47,12 @@ jobs:
     name: ycat
     runs-on: ubuntu-latest
     steps:
-      - name: setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.20"
       - name: checkout
         uses: actions/checkout@v3
+      - name: setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
       - name: build
         run: |
           make ycat/build
@@ -64,12 +64,12 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - name: setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.20"
       - name: checkout
         uses: actions/checkout@v3
+      - name: setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
       - name: measure coverage
         run: |
           make cover


### PR DESCRIPTION
bump actions/setup-go v4.
https://github.com/actions/setup-go#v4

from v4, enabled caching by default.
it will make the CI faster.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification