### PR TITLE
apply go fmt with Go 1.21

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -89,43 +89,42 @@ func (s MapSlice) ToMap() map[interface{}]interface{} {
 //
 // The field tag format accepted is:
 //
-//     `(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
+//	`(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
 //
 // The following flags are currently supported:
 //
-//     omitempty    Only include the field if it's not set to the zero
-//                  value for the type or to empty slices or maps.
-//                  Zero valued structs will be omitted if all their public
-//                  fields are zero, unless they implement an IsZero
-//                  method (see the IsZeroer interface type), in which
-//                  case the field will be included if that method returns true.
+//	omitempty    Only include the field if it's not set to the zero
+//	             value for the type or to empty slices or maps.
+//	             Zero valued structs will be omitted if all their public
+//	             fields are zero, unless they implement an IsZero
+//	             method (see the IsZeroer interface type), in which
+//	             case the field will be included if that method returns true.
 //
-//     flow         Marshal using a flow style (useful for structs,
-//                  sequences and maps).
+//	flow         Marshal using a flow style (useful for structs,
+//	             sequences and maps).
 //
-//     inline       Inline the field, which must be a struct or a map,
-//                  causing all of its fields or keys to be processed as if
-//                  they were part of the outer struct. For maps, keys must
-//                  not conflict with the yaml keys of other struct fields.
+//	inline       Inline the field, which must be a struct or a map,
+//	             causing all of its fields or keys to be processed as if
+//	             they were part of the outer struct. For maps, keys must
+//	             not conflict with the yaml keys of other struct fields.
 //
-//     anchor       Marshal with anchor. If want to define anchor name explicitly, use anchor=name style.
-//                  Otherwise, if used 'anchor' name only, used the field name lowercased as the anchor name
+//	anchor       Marshal with anchor. If want to define anchor name explicitly, use anchor=name style.
+//	             Otherwise, if used 'anchor' name only, used the field name lowercased as the anchor name
 //
-//     alias        Marshal with alias. If want to define alias name explicitly, use alias=name style.
-//                  Otherwise, If omitted alias name and the field type is pointer type,
-//                  assigned anchor name automatically from same pointer address.
+//	alias        Marshal with alias. If want to define alias name explicitly, use alias=name style.
+//	             Otherwise, If omitted alias name and the field type is pointer type,
+//	             assigned anchor name automatically from same pointer address.
 //
 // In addition, if the key is "-", the field is ignored.
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
-//     yaml.Marshal(&T{F: 1}) // Returns "a: 1\nb: 0\n"
-//
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
+//	yaml.Marshal(&T{F: 1}) // Returns "a: 1\nb: 0\n"
 func Marshal(v interface{}) ([]byte, error) {
 	return MarshalWithOptions(v)
 }
@@ -167,16 +166,15 @@ func ValueToNode(v interface{}, opts ...EncodeOption) (ast.Node, error) {
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     var t T
-//     yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	var t T
+//	yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
 //
 // See the documentation of Marshal for the format of tags and a list of
 // supported tag options.
-//
 func Unmarshal(data []byte, v interface{}) error {
 	return UnmarshalWithOptions(data, v)
 }


### PR DESCRIPTION
go fmt now formats godoc comments.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification