### PR TITLE
feat: preserve line breaks from original input

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -283,7 +283,7 @@ func checkLineBreak(t *token.Token) bool {
 		lbc := "\n"
 		prev := t.Prev
 		var adjustment int
-		// if the previous type is sequence entry user the previous type for that
+		// if the previous type is sequence entry use the previous type for that
 		if prev.Type == token.SequenceEntryType {
 			// as well as switching to previous type count any new lines in origin to account for:
 			// -

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -592,6 +592,10 @@ i: 'j'
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
+			got := f.String()
+			if got != strings.TrimPrefix(test.expect, "\n") {
+				t.Fatalf("failed to parse comment:\nexpected:\n%s\ngot:\n%s", strings.TrimPrefix(test.expect, "\n"), got)
+			}
 			var v Visitor
 			for _, doc := range f.Docs {
 				ast.Walk(&v, doc.Body)
@@ -600,6 +604,268 @@ i: 'j'
 			if test.expect != expect {
 				tokens.Dump()
 				t.Fatalf("unexpected output: [%s] != [%s]", test.expect, expect)
+			}
+		})
+	}
+}
+
+func TestParseWhitespace(t *testing.T) {
+	tests := []struct {
+		source string
+		expect string
+	}{
+		{
+			`
+a: b
+
+c: d
+
+
+e: f
+g: h
+`,
+			`
+a: b
+
+c: d
+
+e: f
+g: h
+`,
+		},
+		{
+			`
+a:
+  - b: c
+    d: e
+
+  - f: g
+    h: i
+`,
+			`
+a:
+  - b: c
+    d: e
+
+  - f: g
+    h: i
+`,
+		},
+		{
+			`
+a:
+  - b: c
+    d: e
+
+  - f: g
+    h: i
+`,
+			`
+a:
+  - b: c
+    d: e
+
+  - f: g
+    h: i
+`,
+		},
+		{
+			`
+a:
+- b: c
+  d: e
+
+- f: g
+  h: i
+`,
+			`
+a:
+- b: c
+  d: e
+
+- f: g
+  h: i
+`,
+		},
+		{
+			`
+a:
+# comment 1
+- b: c
+  d: e
+
+# comment 2
+- f: g
+  h: i
+`,
+			`
+a:
+# comment 1
+- b: c
+  d: e
+
+# comment 2
+- f: g
+  h: i
+`,
+		},
+		{
+			`
+a:
+  # comment 1
+  - b: c
+    # comment 2
+    d: e
+
+  # comment 3
+  # comment 4
+  - f: g
+    h: i # comment 5
+`,
+			`
+a:
+  # comment 1
+  - b: c
+    # comment 2
+    d: e
+
+  # comment 3
+  # comment 4
+  - f: g
+    h: i # comment 5
+`,
+		},
+		{
+			`
+a:
+  # comment 1
+  - b: c
+    # comment 2
+    d: e
+
+  # comment 3
+  # comment 4
+  - f: |
+      g
+      g
+    h: i # comment 5
+`,
+			`
+a:
+  # comment 1
+  - b: c
+    # comment 2
+    d: e
+
+  # comment 3
+  # comment 4
+  - f: |
+      g
+      g
+    h: i # comment 5
+`,
+		},
+		{
+			`
+a:
+  # comment 1
+  - b: c
+    # comment 2
+    d: e
+
+  # comment 3
+  # comment 4
+  - f: |
+      asd
+      def
+
+    h: i # comment 5
+`,
+			`
+a:
+  # comment 1
+  - b: c
+    # comment 2
+    d: e
+
+  # comment 3
+  # comment 4
+  - f: |
+      asd
+      def
+
+    h: i # comment 5
+`,
+		},
+		{
+			`
+- b: c
+  d: e
+
+- f: g
+  h: i # comment 4
+		`,
+			`
+- b: c
+  d: e
+
+- f: g
+  h: i # comment 4
+`,
+		},
+		{
+			`
+a: null
+b: null
+
+d: e
+`,
+			`
+a: null
+b: null
+
+d: e
+`,
+		},
+		{
+			`
+foo:
+  bar: null # comment
+
+  baz: 1
+`,
+			`
+foo:
+  bar: null # comment
+
+  baz: 1
+`,
+		},
+		{
+			`
+foo:
+  bar: null # comment
+
+baz: 1
+`,
+			`
+foo:
+  bar: null # comment
+
+baz: 1
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.source, func(t *testing.T) {
+			f, err := parser.ParseBytes([]byte(test.source), parser.ParseComments)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := f.String()
+			if got != strings.TrimPrefix(test.expect, "\n") {
+				t.Fatalf("failed to parse comment:\nexpected:\n%s\ngot:\n%s", strings.TrimPrefix(test.expect, "\n"), got)
 			}
 		})
 	}
@@ -617,10 +883,11 @@ func TestNewLineChar(t *testing.T) {
 		}
 		actual := fmt.Sprintf("%v", ast)
 		expect := `a: "a"
+
 b: 1
 `
 		if expect != actual {
-			t.Fatal("unexpected result")
+			t.Fatalf("unexpected result\nexpected:\n%s\ngot:\n%s", expect, actual)
 		}
 	}
 }
@@ -827,8 +1094,9 @@ foo:
 		if len(f.Docs) != 1 {
 			t.Fatal("failed to parse content with same line comment")
 		}
-		if f.Docs[0].String() != strings.TrimPrefix(expected, "\n") {
-			t.Fatal("failed to parse comment")
+		got := f.Docs[0].String()
+		if got != strings.TrimPrefix(expected, "\n") {
+			t.Fatalf("failed to parse comment:\nexpected:\n%s\ngot:\n%s", strings.TrimPrefix(expected, "\n"), got)
 		}
 	})
 	t.Run("next line", func(t *testing.T) {
@@ -849,8 +1117,9 @@ foo:
 		if len(f.Docs) != 1 {
 			t.Fatal("failed to parse content with next line comment")
 		}
-		if f.Docs[0].String() != strings.TrimPrefix(expected, "\n") {
-			t.Fatal("failed to parse comment")
+		got := f.Docs[0].String()
+		if got != strings.TrimPrefix(expected, "\n") {
+			t.Fatalf("failed to parse comment:\nexpected:\n%s\ngot:\n%s", strings.TrimPrefix(expected, "\n"), got)
 		}
 	})
 	t.Run("next line and different indent", func(t *testing.T) {
@@ -870,8 +1139,9 @@ baz: 1`
 foo:
   bar: null # comment
 baz: 1`
-		if f.Docs[0].String() != strings.TrimPrefix(expected, "\n") {
-			t.Fatal("failed to parse comment")
+		got := f.Docs[0].String()
+		if got != strings.TrimPrefix(expected, "\n") {
+			t.Fatalf("failed to parse comment:\nexpected:\n%s\ngot:\n%s", strings.TrimPrefix(expected, "\n"), got)
 		}
 	})
 }
@@ -897,8 +1167,9 @@ foo:
   - bar: 1
 baz:
   - xxx`
-	if f.Docs[0].String() != strings.TrimPrefix(expected, "\n") {
-		t.Fatal("failed to parse comment")
+	got := f.Docs[0].String()
+	if got != strings.TrimPrefix(expected, "\n") {
+		t.Fatalf("failed to parse comment:\nexpected:\n%s\ngot:\n%s", strings.TrimPrefix(expected, "\n"), got)
 	}
 	t.Run("foo[0].bar", func(t *testing.T) {
 		path, err := yaml.PathString("$.foo[0].bar")
@@ -999,8 +1270,7 @@ func (c *pathCapturer) Visit(node ast.Node) ast.Visitor {
 	return c
 }
 
-type Visitor struct {
-}
+type Visitor struct{}
 
 func (v *Visitor) Visit(node ast.Node) ast.Visitor {
 	tk := node.GetToken()


### PR DESCRIPTION
## Motivation

Preserve the line breaks from input.

We use this project as dependency in a project that round trips YAML, this attempts to try and preserve the formatting. It will only ever add one line break between lines regardless of input.

## Changes
- add `checkLineBreak` method that uses the previous token to calculate if there should be a line break
- account for `token.SequenceEntryType`  using the previous token of that.
- ensure multiline strings are accounted for in the logic
- add a new table test
- update existing test to validate string output has changed
- update existing tests to output differences on failure

<!--Before submitting your PR, please confirm the following.-->

## Checks

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification