### PR TITLE
fix: Treat empty nodes as zero values

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -592,6 +592,10 @@ func TestDecoder(t *testing.T) {
 			map[string]interface{}{"v": []interface{}{"A", "B"}},
 		},
 		{
+			"v:\n-",
+			map[string][]string{"v": []string{""}},
+		},
+		{
 			"v:\n - A\n - B\n - C",
 			map[string][]string{"v": []string{"A", "B", "C"}},
 		},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -327,20 +327,23 @@ func (p *parser) parseSequenceEntry(ctx *context) (*ast.SequenceNode, error) {
 	for tk.Type == token.SequenceEntryType {
 		ctx.progress(1) // skip sequence token
 		tk = ctx.currentToken()
-		if tk == nil {
-			return nil, errors.ErrSyntax("empty sequence entry", ctx.previousToken())
-		}
 		var comment *ast.CommentGroupNode
-		if tk.Type == token.CommentType {
-			comment = p.parseCommentOnly(ctx)
-			tk = ctx.currentToken()
-			if tk.Type == token.SequenceEntryType {
-				ctx.progress(1) // skip sequence token
+		var value ast.Node
+		var err error
+		if tk == nil {
+			value = &ast.NullNode{}
+		} else {
+			if tk.Type == token.CommentType {
+				comment = p.parseCommentOnly(ctx)
+				tk = ctx.currentToken()
+				if tk.Type == token.SequenceEntryType {
+					ctx.progress(1) // skip sequence token
+				}
 			}
-		}
-		value, err := p.parseToken(ctx.withIndex(uint(len(sequenceNode.Values))), ctx.currentToken())
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse sequence")
+			value, err = p.parseToken(ctx.withIndex(uint(len(sequenceNode.Values))), ctx.currentToken())
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse sequence")
+			}
 		}
 		if comment != nil {
 			comment.SetPath(ctx.withIndex(uint(len(sequenceNode.Values))).path)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -681,19 +681,6 @@ a
        ^
 `,
 		},
-		{
-			`
-a:
-- b: c
-- `,
-			`
-[4:1] empty sequence entry
-   2 | a:
-   3 | - b: c
->  4 | -
-       ^
-`,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.source, func(t *testing.T) {


### PR DESCRIPTION
Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification


This code begins to address #414. Basically the idea is, "empty sequence entry" is not actually an "error" and should be treated as a "NullNode" instead.

There are still several additional issues code doesn't yet address, like:
- `foo:\n-` is treated like a zero length list (which I think is the same behavior as a bug in go-yaml https://github.com/go-yaml/yaml/issues/1011)
- `foo:\n  -` errors out with "string was used where sequence is expected" (when it also should be treated as `null`)

Looking for confirmation that I've identified an actual issue and am on the right track to fix it, at which point I will continue trying to address and test for these additional cases.
