### PR TITLE
Return existing builder from `PathBuilder.Root()` instead of creating a new one.

### DIFF
--- a/path.go
+++ b/path.go
@@ -372,7 +372,9 @@ type PathBuilder struct {
 // Root add '$' to current path.
 func (b *PathBuilder) Root() *PathBuilder {
 	root := newRootNode()
-	return &PathBuilder{root: root, node: root}
+	b.root = root
+	b.node = root
+	return b
 }
 
 // IndexAll add '[*]' to current path.

--- a/path_test.go
+++ b/path_test.go
@@ -50,6 +50,22 @@ func TestPathBuilder(t *testing.T) {
 	}
 }
 
+func TestPathBuilderNoChain(t *testing.T) {
+	builder := yaml.PathBuilder{}
+	builder.Root()
+	builder.Child("a")
+	builder.Child("b")
+	builder.Index(0)
+	path := builder.Build()
+
+	expected := `$.a.b[0]`
+	got := path.String()
+
+	if expected != got {
+		t.Fatalf("failed to build path. expected:[%q] but got:[%q]", expected, got)
+	}
+}
+
 func TestPath(t *testing.T) {
 	yml := `
 store:


### PR DESCRIPTION
- [x] Describe the purpose for which you created this PR.  

This PR fixes a bug that I came across. It is triggered by a piece of code like this:

```go
package main

import (
	"fmt"

	yaml "github.com/goccy/go-yaml"
)

func main() {
	builder := yaml.PathBuilder{}

	builder.Root()
	builder.Child("a")
	builder.Child("b")
	builder.Index(0)

	path := builder.Build()

	fmt.Println(path.String())
}
```

On the current `master` this code causes a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x481ff8]

goroutine 1 [running]:
github.com/goccy/go-yaml.(*PathBuilder).child(...)
        /home/tobi/git/oss/go-yaml/path.go:417
github.com/goccy/go-yaml.(*PathBuilder).Child(0xc00011cf18, {0x4bd7e8?, 0xc00011cf30?})
        /home/tobi/git/oss/go-yaml/path.go:423 +0xb8
main.main()
        /home/tobi/git/oss/go-yaml/tmp/bug.go:13 +0x45
exit status 2
```

The root cause is that the `PathBuilder.Root()` method instanciates a new `PathBuilder` instance instead of mutating and returning the reciever. This is inconsistent with the similar methods `IndexAll`, `Recursive`, `Index` and `Child` and with my understanding of the builder pattern.

The given code sample assumes that the `.Root()` call mutates the builder, but it doesn't. Therefore the resulting `path` built by `builder.Build()` does not have a root. This in turn causes the panic when calling `path.String()`.

This is not caught by the existing tests,  because the existing tests use method chaining, which executes the next call on the builder returned by `builder.Root()`, which is a builder that has a root and therefore works as expected.

The fact that `path.String()` causes a panic in this case might be a separate issue that I didn't look into further.

- [x] Create test code that corresponds to the modification