### PR TITLE
fix: remove any trailing empty lines if the block scalar has strip indicator

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -849,7 +849,23 @@ func TestDecoder(t *testing.T) {
 			},
 		},
 		{
+			"v:\n- A\n- |-\n  B\n  C\n\n\n",
+			map[string][]string{
+				"v": {
+					"A", "B\nC",
+				},
+			},
+		},
+		{
 			"v:\n- A\n- >-\n  B\n  C\n",
+			map[string][]string{
+				"v": {
+					"A", "B C",
+				},
+			},
+		},
+		{
+			"v:\n- A\n- >-\n  B\n  C\n\n\n",
 			map[string][]string{
 				"v": {
 					"A", "B C",

--- a/scanner/context.go
+++ b/scanner/context.go
@@ -196,9 +196,16 @@ func (c *Context) existsBuffer() bool {
 
 func (c *Context) bufferedSrc() []rune {
 	src := c.buf[:c.notSpaceCharPos]
-	if len(src) > 0 && src[len(src)-1] == '\n' && c.isDocument() && c.literalOpt == "-" {
-		// remove end '\n' character
-		src = src[:len(src)-1]
+	if c.isDocument() && c.literalOpt == "-" {
+		// remove end '\n' character and trailing empty lines
+		// https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator
+		for {
+			if len(src) > 0 && src[len(src)-1] == '\n' {
+				src = src[:len(src)-1]
+				continue
+			}
+			break
+		}
 	}
 	return src
 }


### PR DESCRIPTION
## What

SSIA

## Why

> Stripping is specified by the “-” chomping indicator. In this case, the final [line break](https://yaml.org/spec/1.2.2/#line-break-characters) and any trailing [empty lines](https://yaml.org/spec/1.2.2/#empty-lines) are excluded from the [scalar’s content](https://yaml.org/spec/1.2.2/#scalar).

https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator

Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification