### PR TITLE
Replace deprecated `io/ioutil`

### DIFF
--- a/cmd/ycat/ycat.go
+++ b/cmd/ycat/ycat.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/fatih/color"
@@ -24,7 +23,7 @@ func _main(args []string) error {
 		return errors.New("ycat: usage: ycat file.yml")
 	}
 	filename := args[1]
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}

--- a/decode.go
+++ b/decode.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -1621,7 +1620,7 @@ func (d *Decoder) resolveReference() error {
 		}
 	}
 	for _, reader := range d.referenceReaders {
-		bytes, err := ioutil.ReadAll(reader)
+		bytes, err := io.ReadAll(reader)
 		if err != nil {
 			return errors.Wrapf(err, "failed to read buffer")
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/goccy/go-yaml/ast"
@@ -730,7 +730,7 @@ func Parse(tokens token.Tokens, mode Mode) (*ast.File, error) {
 
 // Parse parse from filename, and returns ast.File
 func ParseFile(filename string, mode Mode) (*ast.File, error) {
-	file, err := ioutil.ReadFile(filename)
+	file, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read file: %s", filename)
 	}


### PR DESCRIPTION
Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
  [`io/ioutil`](https://pkg.go.dev/io/ioutil) is deprecated since Go 1.16. It's replaced with `io` and `os` packages

- [x] ~Create test code that corresponds to the modification~