### PR TITLE
Quote is required even if it begins with backquote.

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -319,6 +319,11 @@ func TestEncoder(t *testing.T) {
 			nil,
 		},
 		{
+			"a: \"`b` c\"\n",
+			map[string]string{"a": "`b` c"},
+			nil,
+		},
+		{
 			"a: 100.5\n",
 			map[string]interface{}{
 				"a": 100.5,

--- a/token/token.go
+++ b/token/token.go
@@ -623,7 +623,7 @@ func IsNeedQuoted(value string) bool {
 	}
 	first := value[0]
 	switch first {
-	case '*', '&', '[', '{', '}', ']', ',', '!', '|', '>', '%', '\'', '"', '@', ' ':
+	case '*', '&', '[', '{', '}', ']', ',', '!', '|', '>', '%', '\'', '"', '@', ' ', '`':
 		return true
 	}
 	last := value[len(value)-1]


### PR DESCRIPTION
Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification

Hi @goccy!

I noticed when using a mix of goccy/go-yaml and go-yaml/yaml that backquotes also cannot be used at the beginning of a token.

https://go.dev/play/p/ysabzaYClh3

I also got an error at https://www.yamllint.com/.

According to https://yaml.org/spec/1.2.2/  backquote (<code>`</code>) is reserved.

> The “@” (x40, at) and “`” (x60, grave accent) are reserved for future use.

Thank you.