### PR TITLE
Add support for escaped UTF-16 surrogate pairs

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -438,6 +438,18 @@ func TestDecoder(t *testing.T) {
 			map[interface{}]interface{}{"1": `a/b/c/d`},
 		},
 		{
+			`"\ud83e\udd23"`,
+			"🤣",
+		},
+		{
+			`"\uD83D\uDE00\uD83D\uDE01"`,
+			"😀😁",
+		},
+		{
+			`"\uD83D\uDE00a\uD83D\uDE01"`,
+			"😀a😁",
+		},
+		{
 			"'1': \"2\\n3\"",
 			map[interface{}]interface{}{"1": "2\n3"},
 		},


### PR DESCRIPTION
I have followed the convention above that error handling is TODO, but I can start implementing it if you like.

References:

* https://russellcottrell.com/greek/utilities/SurrogatePairCalculator.htm
* https://mathiasbynens.be/notes/javascript-unicode
* https://en.wikipedia.org/wiki/UTF-16#U+D800_to_U+DFFF_(surrogates)