### PR TITLE
Add InterfaceCustomUnmarshaler and test case to override interface type

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -24,42 +24,44 @@ import (
 
 // Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
-	reader               io.Reader
-	referenceReaders     []io.Reader
-	anchorNodeMap        map[string]ast.Node
-	anchorValueMap       map[string]reflect.Value
-	customUnmarshalerMap map[reflect.Type]func(interface{}, []byte) error
-	toCommentMap         CommentMap
-	opts                 []DecodeOption
-	referenceFiles       []string
-	referenceDirs        []string
-	isRecursiveDir       bool
-	isResolvedReference  bool
-	validator            StructValidator
-	disallowUnknownField bool
-	disallowDuplicateKey bool
-	useOrderedMap        bool
-	useJSONUnmarshaler   bool
-	parsedFile           *ast.File
-	streamIndex          int
+	reader                        io.Reader
+	referenceReaders              []io.Reader
+	anchorNodeMap                 map[string]ast.Node
+	anchorValueMap                map[string]reflect.Value
+	customUnmarshalerMap          map[reflect.Type]func(interface{}, []byte) error
+	customInterfaceUnmarshalerMap map[reflect.Type]func(interface{}, func(interface{}) error) error
+	toCommentMap                  CommentMap
+	opts                          []DecodeOption
+	referenceFiles                []string
+	referenceDirs                 []string
+	isRecursiveDir                bool
+	isResolvedReference           bool
+	validator                     StructValidator
+	disallowUnknownField          bool
+	disallowDuplicateKey          bool
+	useOrderedMap                 bool
+	useJSONUnmarshaler            bool
+	parsedFile                    *ast.File
+	streamIndex                   int
 }
 
 // NewDecoder returns a new decoder that reads from r.
 func NewDecoder(r io.Reader, opts ...DecodeOption) *Decoder {
 	return &Decoder{
-		reader:               r,
-		anchorNodeMap:        map[string]ast.Node{},
-		anchorValueMap:       map[string]reflect.Value{},
-		customUnmarshalerMap: map[reflect.Type]func(interface{}, []byte) error{},
-		opts:                 opts,
-		referenceReaders:     []io.Reader{},
-		referenceFiles:       []string{},
-		referenceDirs:        []string{},
-		isRecursiveDir:       false,
-		isResolvedReference:  false,
-		disallowUnknownField: false,
-		disallowDuplicateKey: false,
-		useOrderedMap:        false,
+		reader:                        r,
+		anchorNodeMap:                 map[string]ast.Node{},
+		anchorValueMap:                map[string]reflect.Value{},
+		customUnmarshalerMap:          map[reflect.Type]func(interface{}, []byte) error{},
+		customInterfaceUnmarshalerMap: map[reflect.Type]func(interface{}, func(interface{}) error) error{},
+		opts:                          opts,
+		referenceReaders:              []io.Reader{},
+		referenceFiles:                []string{},
+		referenceDirs:                 []string{},
+		isRecursiveDir:                false,
+		isResolvedReference:           false,
+		disallowUnknownField:          false,
+		disallowDuplicateKey:          false,
+		useOrderedMap:                 false,
 	}
 }
 
@@ -656,7 +658,6 @@ func (d *Decoder) unmarshalerFromCustomUnmarshalerMap(t reflect.Type) (func(inte
 	if unmarshaler, exists := d.customUnmarshalerMap[t]; exists {
 		return unmarshaler, exists
 	}
-
 	globalCustomUnmarshalerMu.Lock()
 	defer globalCustomUnmarshalerMu.Unlock()
 	if unmarshaler, exists := globalCustomUnmarshalerMap[t]; exists {
@@ -665,9 +666,38 @@ func (d *Decoder) unmarshalerFromCustomUnmarshalerMap(t reflect.Type) (func(inte
 	return nil, false
 }
 
+func (d *Decoder) existsTypeInCustomInterfaceUnmarshalerMap(t reflect.Type) bool {
+	if _, exists := d.customInterfaceUnmarshalerMap[t]; exists {
+		return true
+	}
+
+	globalCustomInterfaceUnmarshalerMu.Lock()
+	defer globalCustomInterfaceUnmarshalerMu.Unlock()
+	if _, exists := globalCustomInterfaceUnmarshalerMap[t]; exists {
+		return true
+	}
+	return false
+}
+
+func (d *Decoder) unmarshalerFromCustomInterfaceUnmarshalerMap(t reflect.Type) (func(interface{}, func(interface{}) error) error, bool) {
+	if unmarshaler, exists := d.customInterfaceUnmarshalerMap[t]; exists {
+		return unmarshaler, exists
+	}
+
+	globalCustomInterfaceUnmarshalerMu.Lock()
+	defer globalCustomInterfaceUnmarshalerMu.Unlock()
+	if unmarshaler, exists := globalCustomInterfaceUnmarshalerMap[t]; exists {
+		return unmarshaler, exists
+	}
+	return nil, false
+}
+
 func (d *Decoder) canDecodeByUnmarshaler(dst reflect.Value) bool {
 	ptrValue := dst.Addr()
 	if d.existsTypeInCustomUnmarshalerMap(ptrValue.Type()) {
+		return true
+	}
+	if d.existsTypeInCustomInterfaceUnmarshalerMap(ptrValue.Type()) {
 		return true
 	}
 	iface := ptrValue.Interface()
@@ -700,6 +730,21 @@ func (d *Decoder) decodeByUnmarshaler(ctx context.Context, dst reflect.Value, sr
 			return errors.Wrapf(err, "failed to UnmarshalYAML")
 		}
 		if err := unmarshaler(ptrValue.Interface(), b); err != nil {
+			return errors.Wrapf(err, "failed to UnmarshalYAML")
+		}
+		return nil
+	}
+	if unmarshaler, exists := d.unmarshalerFromCustomInterfaceUnmarshalerMap(ptrValue.Type()); exists {
+		if err := unmarshaler(ptrValue.Interface(), func(v interface{}) error {
+			rv := reflect.ValueOf(v)
+			if rv.Type().Kind() != reflect.Ptr {
+				return errors.ErrDecodeRequiredPointerType
+			}
+			if err := d.decodeValue(ctx, rv.Elem(), src); err != nil {
+				return errors.Wrapf(err, "failed to decode value")
+			}
+			return nil
+		}); err != nil {
 			return errors.Wrapf(err, "failed to UnmarshalYAML")
 		}
 		return nil

--- a/decode_test.go
+++ b/decode_test.go
@@ -1942,6 +1942,55 @@ func TestDecoder_CustomUnmarshaler(t *testing.T) {
 	})
 }
 
+func TestDecoder_CustomInterfaceUnmarshaler(t *testing.T) {
+	t.Run("override struct type", func(t *testing.T) {
+		type T struct {
+			Foo string `yaml:"foo"`
+		}
+		src := []byte(`foo: "bar"`)
+		var v T
+		if err := yaml.UnmarshalWithOptions(src, &v, yaml.CustomInterfaceUnmarshaler[T](func(dst *T, f func(interface{}) error) error {
+			var m map[string]string
+			if err := f(&m); err != nil {
+				t.Fatal(err)
+			}
+			if m["foo"] != "bar" {
+				t.Fatalf("failed to use unmarshal function. got %q", m["foo"])
+			}
+			dst.Foo = "bazbaz" // assign another value to target
+			return nil
+		})); err != nil {
+			t.Fatal(err)
+		}
+		if v.Foo != "bazbaz" {
+			t.Fatalf("failed to switch to custom interface unmarshaler. got: %v", v.Foo)
+		}
+	})
+	t.Run("override bytes type", func(t *testing.T) {
+		type T struct {
+			Foo []byte `yaml:"foo"`
+		}
+		src := []byte(`foo: "bar"`)
+		var v T
+		if err := yaml.UnmarshalWithOptions(src, &v, yaml.CustomInterfaceUnmarshaler[[]byte](func(dst *[]byte, f func(interface{}) error) error {
+			var str string
+			if err := f(&str); err != nil {
+				t.Fatal(err)
+			}
+			if str != "bar" {
+				t.Fatalf("failed to use unmarshal function. got %q", str)
+			}
+			*dst = []byte("bazbaz")
+			return nil
+		})); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(v.Foo, []byte("bazbaz")) {
+			t.Fatalf("failed to switch to custom interface unmarshaler. got: %q", v.Foo)
+		}
+	})
+}
+
 type unmarshalContext struct {
 	v int
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -1251,6 +1251,40 @@ func TestEncoder_CustomMarshaler(t *testing.T) {
 	})
 }
 
+func TestEncoder_CustomInterfaceMarshaler(t *testing.T) {
+	t.Run("override struct type", func(t *testing.T) {
+		type T struct {
+			Foo string `yaml:"foo"`
+		}
+		b, err := yaml.MarshalWithOptions(&T{Foo: "bar"}, yaml.CustomInterfaceMarshaler[T](func(v T) (interface{}, error) {
+			return "override", nil
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(b, []byte("override\n")) {
+			t.Fatalf("failed to switch to custom marshaler. got: %q", b)
+		}
+	})
+	t.Run("override bytes type", func(t *testing.T) {
+		type T struct {
+			Foo []byte `yaml:"foo"`
+		}
+		b, err := yaml.MarshalWithOptions(&T{Foo: []byte("bar")}, yaml.CustomInterfaceMarshaler[[]byte](func(v []byte) (interface{}, error) {
+			if !bytes.Equal(v, []byte("bar")) {
+				t.Fatalf("failed to get src buffer: %q", v)
+			}
+			return "override", nil
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(b, []byte("foo: override\n")) {
+			t.Fatalf("failed to switch to custom marshaler. got: %q", b)
+		}
+	})
+}
+
 func TestEncoder_MultipleDocuments(t *testing.T) {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)


### PR DESCRIPTION
Close #449 

1. Add `CustomInterfaceMarshaler` and `CustomInterfaceUnmarshaler`.

There are `Bytes(Un)Marshaler` and `Interface(Un)Marshaler` interface.
But there is no Interface(Un)Marshaler in Custom(Un)Marshaler.

I want to use InterfaceUnmashaler as CustomUnmarshaler.

Renaming `Custom(Un)marshaler` to `CustomBytes(Un)marshaler` is good for describing function, but it breaks backward compatibility.

The linked issue has a use case and example.

2. Add test cases to override interface type

Added test case corresponding to the example in the linked issue.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification