### PR TITLE
trim right spaces before adding carriage return or linefeed

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -83,6 +83,9 @@ func TestParser(t *testing.T) {
 }`,
 		"\"a\": a\n\"b\": b",
 		"'a': a\n'b': b",
+		"a: \r\n  b: 1\r\n",
+		"a_ok: \r  bc: 2\r",
+		"a_mk: \n  bd: 3\n",
 	}
 	for _, src := range sources {
 		if _, err := parser.Parse(lexer.Tokenize(src), 0); err != nil {


### PR DESCRIPTION
Using a Carriage Return Line Feed (CRLF) pair prevents the scanner from removing the trailing space characters on a line resulting in an `unexpected key name` error.

- [X] Fixes #460
- [X] Adds test cases
