### PR TITLE
Fix decoding of scientific notation

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -928,10 +928,11 @@ func (d *Decoder) decodeValue(ctx context.Context, dst reflect.Value, src ast.No
 				if 0 <= i && i <= math.MaxUint64 && !dst.OverflowUint(uint64(i)) {
 					dst.SetUint(uint64(i))
 					return nil
-				} else { // couldn't be parsed as float
-					return errTypeMismatch(valueType, reflect.TypeOf(v), src.GetToken())
 				}
+			} else { // couldn't be parsed as float
+				return errTypeMismatch(valueType, reflect.TypeOf(v), src.GetToken())
 			}
+
 		default:
 			return errTypeMismatch(valueType, reflect.TypeOf(v), src.GetToken())
 		}

--- a/decode_test.go
+++ b/decode_test.go
@@ -253,6 +253,10 @@ func TestDecoder(t *testing.T) {
 			"v: 4294967295",
 			map[string]uint{"v": math.MaxUint32},
 		},
+		{
+			"v: 1e3",
+			map[string]uint{"v": 1000},
+		},
 
 		// uint64
 		{
@@ -270,6 +274,10 @@ func TestDecoder(t *testing.T) {
 		{
 			"v: 9223372036854775807",
 			map[string]uint64{"v": math.MaxInt64},
+		},
+		{
+			"v: 1e3",
+			map[string]uint64{"v": 1000},
 		},
 
 		// float32
@@ -1078,6 +1086,73 @@ c:
 		{
 			"v: あいうえお\nv2: かきくけこ",
 			map[string]string{"v": "あいうえお", "v2": "かきくけこ"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.source, func(t *testing.T) {
+			buf := bytes.NewBufferString(test.source)
+			dec := yaml.NewDecoder(buf)
+			typ := reflect.ValueOf(test.value).Type()
+			value := reflect.New(typ)
+			if err := dec.Decode(value.Interface()); err != nil {
+				if err == io.EOF {
+					return
+				}
+				t.Fatalf("%s: %+v", test.source, err)
+			}
+			actual := fmt.Sprintf("%+v", value.Elem().Interface())
+			expect := fmt.Sprintf("%+v", test.value)
+			if actual != expect {
+				t.Fatalf("failed to test [%s], actual=[%s], expect=[%s]", test.source, actual, expect)
+			}
+		})
+	}
+}
+
+func TestDecoder_ScientificNotation(t *testing.T) {
+	tests := []struct {
+		source string
+		value  interface{}
+	}{
+		{
+			"v: 1e3",
+			map[string]uint{"v": 1000},
+		},
+		{
+			"v: 1e-3",
+			map[string]uint{"v": 0},
+		},
+		{
+			"v: 1e3",
+			map[string]int{"v": 1000},
+		},
+		{
+			"v: 1e-3",
+			map[string]int{"v": 0},
+		},
+		{
+			"v: 1e3",
+			map[string]float32{"v": 1000},
+		},
+		{
+			"v: 1.0e3",
+			map[string]float64{"v": 1000},
+		},
+		{
+			"v: 1e-3",
+			map[string]float64{"v": 0.001},
+		},
+		{
+			"v: 1.0e-3",
+			map[string]float64{"v": 0.001},
+		},
+		{
+			"v: 1.0e+3",
+			map[string]float64{"v": 1000},
+		},
+		{
+			"v: 1.0e+3",
+			map[string]float64{"v": 1000},
 		},
 	}
 	for _, test := range tests {

--- a/decode_test.go
+++ b/decode_test.go
@@ -1198,6 +1198,17 @@ func TestDecoder_TypeConversionError(t *testing.T) {
 				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
 			}
 		})
+		t.Run("string to uint", func(t *testing.T) {
+			var v T
+			err := yaml.Unmarshal([]byte(`b: str`), &v)
+			if err == nil {
+				t.Fatal("expected to error")
+			}
+			msg := "cannot unmarshal string into Go struct field T.B of type uint"
+			if !strings.Contains(err.Error(), msg) {
+				t.Fatalf("expected error message: %s to contain: %s", err.Error(), msg)
+			}
+		})
 		t.Run("string to bool", func(t *testing.T) {
 			var v T
 			err := yaml.Unmarshal([]byte(`d: str`), &v)

--- a/decode_test.go
+++ b/decode_test.go
@@ -289,6 +289,10 @@ func TestDecoder(t *testing.T) {
 			"v: 18446744073709551616",
 			map[string]float32{"v": float32(math.MaxUint64 + 1)},
 		},
+		{
+			"v: 1e-06",
+			map[string]float32{"v": 1e-6},
+		},
 
 		// float64
 		{
@@ -306,6 +310,10 @@ func TestDecoder(t *testing.T) {
 		{
 			"v: 18446744073709551616",
 			map[string]float64{"v": float64(math.MaxUint64 + 1)},
+		},
+		{
+			"v: 1e-06",
+			map[string]float64{"v": 1e-06},
 		},
 
 		// Timestamps

--- a/encode_test.go
+++ b/encode_test.go
@@ -81,6 +81,16 @@ func TestEncoder(t *testing.T) {
 			nil,
 		},
 		{
+			"v: 1e-06\n",
+			map[string]float32{"v": 1e-06},
+			nil,
+		},
+		{
+			"v: 1e-06\n",
+			map[string]float64{"v": 0.000001},
+			nil,
+		},
+		{
 			"v: 0.123456789\n",
 			map[string]float64{"v": 0.123456789},
 			nil,
@@ -98,6 +108,16 @@ func TestEncoder(t *testing.T) {
 		{
 			"v: 1e+06\n",
 			map[string]float64{"v": 1000000},
+			nil,
+		},
+		{
+			"v: 1e-06\n",
+			map[string]float64{"v": 0.000001},
+			nil,
+		},
+		{
+			"v: 1e-06\n",
+			map[string]float64{"v": 1e-06},
 			nil,
 		},
 		{


### PR DESCRIPTION
Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
Fix #458 as well as similar issues with scientific notation `int` and `uint` values. 
- [x] Create test code that corresponds to the modification
Test code has been added to the encoder to ensure that scientific notation is encoded properly, as well as `TestDecoder_ScientificNotation`. The scientific notation test could be moved to be part of the large `TestDecoder`.

