### PR TITLE
feat(printer): Add support for formatting comment nodes

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -29,6 +29,7 @@ type Printer struct {
 	Bool             PrintFunc
 	String           PrintFunc
 	Number           PrintFunc
+	Comment          PrintFunc
 }
 
 func defaultLineNumberFormat(num int) string {
@@ -80,6 +81,11 @@ func (p *Printer) property(tk *token.Token) *Property {
 	case token.IntegerType, token.FloatType:
 		if p.Number != nil {
 			return p.Number()
+		}
+		return prop
+	case token.CommentType:
+		if p.Comment != nil {
+			return p.Comment()
 		}
 		return prop
 	default:


### PR DESCRIPTION
Hi!

I use `printer` to colorize YAML output to a terminal [here](https://github.com/clevyr/yampl/blob/ef3493e72b79551428337c81afbbf520a2fa6323/internal/colorize/colorize.go#L40-L89) (see also: [`yq` color printer](https://github.com/mikefarah/yq/blob/b80e1cb35e7f4728608d71df002870c379a76e60/pkg/yqlib/color_print.go#L20-L61)), and would like to print comments in gray. This PR adds support for formatting comment nodes.