### PR TITLE
Refactor overflowError to be pretty-printable

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -524,19 +524,6 @@ func (d *Decoder) convertValue(v reflect.Value, typ reflect.Type, src ast.Node) 
 	return v.Convert(typ), nil
 }
 
-type overflowError struct {
-	dstType reflect.Type
-	srcNum  string
-}
-
-func (e *overflowError) Error() string {
-	return fmt.Sprintf("cannot unmarshal %s into Go value of type %s ( overflow )", e.srcNum, e.dstType)
-}
-
-func errOverflow(dstType reflect.Type, num string) *overflowError {
-	return &overflowError{dstType: dstType, srcNum: num}
-}
-
 func errTypeMismatch(dstType, srcType reflect.Type, token *token.Token) *errors.TypeError {
 	return &errors.TypeError{DstType: dstType, SrcType: srcType, Token: token}
 }
@@ -904,7 +891,7 @@ func (d *Decoder) decodeValue(ctx context.Context, dst reflect.Value, src ast.No
 		default:
 			return errTypeMismatch(valueType, reflect.TypeOf(v), src.GetToken())
 		}
-		return errOverflow(valueType, fmt.Sprint(v))
+		return errors.ErrOverflow(valueType, fmt.Sprint(v), src.GetToken())
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		v := d.nodeToValue(src)
 		switch vv := v.(type) {
@@ -936,7 +923,7 @@ func (d *Decoder) decodeValue(ctx context.Context, dst reflect.Value, src ast.No
 		default:
 			return errTypeMismatch(valueType, reflect.TypeOf(v), src.GetToken())
 		}
-		return errOverflow(valueType, fmt.Sprint(v))
+		return errors.ErrOverflow(valueType, fmt.Sprint(v), src.GetToken())
 	}
 	v := reflect.ValueOf(d.nodeToValue(src))
 	if v.IsValid() {


### PR DESCRIPTION
When trying to yaml.Unmarshal a negative number into an uint, the resulting error indicates an overflow with type information, but without the position. For example:

```
cannot unmarshal -23 into Go value of type uint64 ( overflow )
```

From an end user's perspective reading an error for an invalid YAML, this is quite unintuitive. Especially compared to the error message when trying to unmarshal a string into an uint.

```
[1:4] cannot unmarshal string into Go struct field Foo.A of type uint64
    >  1 | a: 'foo'
              ^
```

This change has moved overflowError to internal.errors.overflowError, implementing both the PrettyPrinter and Formatter. Its implementation is uniform with those of the syntaxError and TypeError.
Thus, the error from above now looks like:

```
[1:4] cannot unmarshal -23 into Go value of type uint64 ( overflow )
    >  1 | a: -23
              ^
```