### PR TITLE
Fix "null" string encoded as nil

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -339,9 +339,12 @@ func reservedKeywordToken(typ Type, value, org string, pos *Position) *Token {
 
 func init() {
 	for _, keyword := range reservedNullKeywords {
-		reservedKeywordMap[keyword] = func(value, org string, pos *Position) *Token {
+		f := func(value, org string, pos *Position) *Token {
 			return reservedKeywordToken(NullType, value, org, pos)
 		}
+
+		reservedKeywordMap[keyword] = f
+		reservedEncKeywordMap[keyword] = f
 	}
 	for _, keyword := range reservedBoolKeywords {
 		f := func(value, org string, pos *Position) *Token {

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -121,6 +121,10 @@ func TestIsNeedQuoted(t *testing.T) {
 		" a",
 		" a ",
 		"a ",
+		"null",
+		"Null",
+		"NULL",
+		"~",
 	}
 	for i, test := range needQuotedTests {
 		if !token.IsNeedQuoted(test) {


### PR DESCRIPTION
This PR fixing this open issue: [#413 ](https://github.com/goccy/go-yaml/issues/413)

**Solution**: incorporate each keyword from reservedNullKeywords into reservedEncKeywordMap to indicate that null keywords should be enclosed in quotes. This ensures that only Golang's nil is represented as YAML null.

Currently, any string from reservedNullKeywords is being encoded as YAML null, which is not the intended behavior and may cause confusion. Because users use Golang's nil if they want YAML null and for some reason "null" string if they want string in yaml document

This fix reverts the some behavior that was erroneously changed in this [this commit](https://github.com/goccy/go-yaml/commit/f3319d6c809402b2e4a64de82097d6e7faacfb0c). Prior to this commit, only Golang's nil was represented as YAML null.