### PR TITLE
Fix incorrect colon indicator scanning

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -86,6 +86,7 @@ func TestParser(t *testing.T) {
 		"a: \r\n  b: 1\r\n",
 		"a_ok: \r  bc: 2\r",
 		"a_mk: \n  bd: 3\n",
+		"a: :a",
 	}
 	for _, src := range sources {
 		if _, err := parser.Parse(lexer.Tokenize(src), 0); err != nil {

--- a/scanner/context.go
+++ b/scanner/context.go
@@ -126,7 +126,7 @@ func (c *Context) isEOS() bool {
 }
 
 func (c *Context) isNextEOS() bool {
-	return len(c.src)-1 <= c.idx+1
+	return len(c.src) <= c.idx+1
 }
 
 func (c *Context) next() bool {


### PR DESCRIPTION
fixes #484

`isNextEOS` should return `true` when the next `idx` is out of `src`

- [x] Describe the purpose for which you created this PR.  
- [ ] Create test code that corresponds to the modification