### PR TITLE
Support recursive anchor

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -948,7 +948,21 @@ func TestDecoder(t *testing.T) {
 			"a: &a [1, 2]\nb: *a\n",
 			struct{ B []int }{[]int{1, 2}},
 		},
-
+		{
+			"&0: *0\n*0:\n*0:",
+			map[string]any{"null": nil},
+		},
+		{
+			"key1: &anchor\n  subkey: *anchor\nkey2: *anchor\n",
+			map[string]any{
+				"key1": map[string]any{
+					"subkey": nil,
+				},
+				"key2": map[string]any{
+					"subkey": nil,
+				},
+			},
+		},
 		{
 			"tags:\n- hello-world\na: foo",
 			struct {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -2400,7 +2400,7 @@ func TestInvalid(t *testing.T) {
 		src  string
 	}{
 		{
-			name: "literal opt",
+			name: "literal opt with content",
 			src: `
 a: |invalid
   foo`,


### PR DESCRIPTION
Supports recursive anchor-alias definition, first evaluating to `null`.

fixes https://github.com/goccy/go-yaml/issues/488 https://github.com/goccy/go-yaml/issues/353
fixes https://github.com/goccy/go-yaml/issues/464 : This issue has already been fixed with invalid token feature.