### PR TITLE
prevent unwanted promotions of integers to float (Issue 427)

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -525,6 +525,14 @@ func (e *Encoder) encodeFloat(v float64, bitSize int) ast.Node {
 		// append x.0 suffix to keep float value context
 		value = fmt.Sprintf("%s.0", value)
 	}
+
+	// prevent unwanted promotions of integers to float (Issue 427)
+	intVal := int64(v)
+	if float64(intVal) == v {
+		value := fmt.Sprint(intVal)
+		return ast.Integer(token.New(value, value, e.pos(e.column)))
+	}
+
 	return ast.Float(token.New(value, value, e.pos(e.column)))
 }
 


### PR DESCRIPTION
This patch prevents unnecessary rendering of integers as floats, when they are obtained from earlier unmarshaling into
empty interfaces. For instance, the epoch time "now: 1731277236" might be rendered as "now: 1.731277236e+09", etc.
Test code is in issue 427 which in the third case, this patch will now render more appropriately as an integer.