### PR TITLE
Implement errors.PrettyPrinter for decoding errors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -607,6 +607,16 @@ type unknownFieldError struct {
 	err error
 }
 
+func (e *unknownFieldError) PrettyPrint(p errors.Printer, colored, inclSource bool) error {
+	var pp errors.PrettyPrinter
+	if errors.As(e.err, &pp) {
+		return pp.PrettyPrint(p, colored, inclSource)
+	}
+
+	p.Print(e)
+	return nil
+}
+
 func (e *unknownFieldError) Error() string {
 	return e.err.Error()
 }
@@ -621,6 +631,16 @@ func errUnexpectedNodeType(actual, expected ast.NodeType, tk *token.Token) error
 
 type duplicateKeyError struct {
 	err error
+}
+
+func (e *duplicateKeyError) PrettyPrint(p errors.Printer, colored, inclSource bool) error {
+	var pp errors.PrettyPrinter
+	if errors.As(e.err, &pp) {
+		return pp.PrettyPrint(p, colored, inclSource)
+	}
+
+	p.Print(e)
+	return nil
 }
 
 func (e *duplicateKeyError) Error() string {


### PR DESCRIPTION
This PR is supposed to fix #517 by implementing `errors.PrettyPrinter` interface for decoding errors.

Looking at the source code, the `err` struct fields seems to always be `*yaml.syntaxError`, however it doesn't feel quite right to check for underlying errors' implementation of `PrettyPrinter` and falling back to printing the error message. Perhaps putting the `msg` and the `token` into the struct explicitly would be better.