### PR TITLE
Support to disallow duplicate map key at parsing

### DIFF
--- a/option.go
+++ b/option.go
@@ -54,7 +54,6 @@ func Validator(v StructValidator) DecodeOption {
 func Strict() DecodeOption {
 	return func(d *Decoder) error {
 		d.disallowUnknownField = true
-		d.disallowDuplicateKey = true
 		return nil
 	}
 }
@@ -69,10 +68,10 @@ func DisallowUnknownField() DecodeOption {
 	}
 }
 
-// DisallowDuplicateKey causes an error when mapping keys that are duplicates
-func DisallowDuplicateKey() DecodeOption {
+// AllowDuplicateMapKey ignore syntax error when mapping keys that are duplicates.
+func AllowDuplicateMapKey() DecodeOption {
 	return func(d *Decoder) error {
-		d.disallowDuplicateKey = true
+		d.allowDuplicateMapKey = true
 		return nil
 	}
 }

--- a/parser/option.go
+++ b/parser/option.go
@@ -1,0 +1,12 @@
+package parser
+
+// Option represents parser's option.
+type Option func(p *parser)
+
+// AllowDuplicateMapKey allow the use of keys with the same name in the same map,
+// but by default, this is not permitted.
+func AllowDuplicateMapKey() Option {
+	return func(p *parser) {
+		p.allowDuplicateMapKey = true
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1286,6 +1286,42 @@ a:
           ^
 `,
 		},
+		{
+			`
+foo:
+  bar:
+    foo: 2
+  baz:
+    foo: 3
+foo: 2
+`,
+			`
+[7:1] mapping key "foo" already defined at [2:1]
+   4 |     foo: 2
+   5 |   baz:
+   6 |     foo: 3
+>  7 | foo: 2
+       ^
+`,
+		},
+		{
+			`
+foo:
+  bar:
+    foo: 2
+  baz:
+    foo: 3
+    foo: 4
+`,
+			`
+[7:5] mapping key "foo" already defined at [6:5]
+   4 |     foo: 2
+   5 |   baz:
+   6 |     foo: 3
+>  7 |     foo: 4
+           ^
+`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.source, func(t *testing.T) {


### PR DESCRIPTION
fix https://github.com/goccy/go-yaml/issues/226

## Breaking Changes

Previously, using the same map key did not result in a parsing error, but from now on, it will throw an error by default. If you want to keep the previous behavior, specify the `parser.AllowDuplicateMapKey()` option. Similarly, during Decode, it will also throw an error by default. To keep the previous behavior, specify the `yaml.AllowDuplicateMapKey()` option when decoding.

Also, I deprecated `yaml.DisallowDuplicateKey` option. That is not necessary.