### PR TITLE
Replace fmt.Sprint with faster alternatives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,12 @@ linters-settings:
       - tests
   misspell:
     locale: US
+  perfsprint:
+    int-conversion: false
+    err-error: false
+    errorf: true
+    sprintf1: false
+    strconcat: false
   staticcheck:
     checks: ["all", "-ST1000", "-ST1005"]
 
@@ -31,6 +37,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - perfsprint
     - staticcheck
     - typecheck
     - unused

--- a/decode.go
+++ b/decode.go
@@ -676,13 +676,13 @@ func (d *Decoder) convertValue(v reflect.Value, typ reflect.Type, src ast.Node) 
 	// cast value to string
 	switch v.Type().Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return reflect.ValueOf(fmt.Sprint(v.Int())), nil
+		return reflect.ValueOf(strconv.FormatInt(v.Int(), 10)), nil
 	case reflect.Float32, reflect.Float64:
 		return reflect.ValueOf(fmt.Sprint(v.Float())), nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return reflect.ValueOf(fmt.Sprint(v.Uint())), nil
+		return reflect.ValueOf(strconv.FormatUint(v.Uint(), 10)), nil
 	case reflect.Bool:
-		return reflect.ValueOf(fmt.Sprint(v.Bool())), nil
+		return reflect.ValueOf(strconv.FormatBool(v.Bool())), nil
 	}
 	if !v.Type().ConvertibleTo(typ) {
 		return reflect.Zero(typ), errors.ErrTypeMismatch(typ, v.Type(), src.GetToken())
@@ -936,7 +936,7 @@ func (d *Decoder) decodeByUnmarshaler(ctx context.Context, dst reflect.Value, sr
 		}
 	}
 
-	return fmt.Errorf("does not implemented Unmarshaler")
+	return errors.New("does not implemented Unmarshaler")
 }
 
 var (

--- a/decode_test.go
+++ b/decode_test.go
@@ -2076,13 +2076,13 @@ type unmarshalContext struct {
 func (c *unmarshalContext) UnmarshalYAML(ctx context.Context, b []byte) error {
 	v, ok := ctx.Value("k").(int)
 	if !ok {
-		return fmt.Errorf("cannot get valid context")
+		return errors.New("cannot get valid context")
 	}
 	if v != 1 {
-		return fmt.Errorf("cannot get valid context")
+		return errors.New("cannot get valid context")
 	}
 	if string(b) != "1" {
-		return fmt.Errorf("cannot get valid bytes")
+		return errors.New("cannot get valid bytes")
 	}
 	c.v = v
 	return nil

--- a/encode.go
+++ b/encode.go
@@ -500,12 +500,12 @@ func (e *Encoder) encodeNil() *ast.NullNode {
 }
 
 func (e *Encoder) encodeInt(v int64) *ast.IntegerNode {
-	value := fmt.Sprint(v)
+	value := strconv.FormatInt(v, 10)
 	return ast.Integer(token.New(value, value, e.pos(e.column)))
 }
 
 func (e *Encoder) encodeUint(v uint64) *ast.IntegerNode {
-	value := fmt.Sprint(v)
+	value := strconv.FormatUint(v, 10)
 	return ast.Integer(token.New(value, value, e.pos(e.column)))
 }
 
@@ -556,7 +556,7 @@ func (e *Encoder) encodeString(v string, column int) *ast.StringNode {
 }
 
 func (e *Encoder) encodeBool(v bool) *ast.BoolNode {
-	value := fmt.Sprint(v)
+	value := strconv.FormatBool(v)
 	return ast.Bool(token.New(value, value, e.pos(e.column)))
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -3,6 +3,7 @@ package yaml_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -1398,10 +1399,10 @@ type marshalContext struct{}
 func (c *marshalContext) MarshalYAML(ctx context.Context) ([]byte, error) {
 	v, ok := ctx.Value("k").(int)
 	if !ok {
-		return nil, fmt.Errorf("cannot get valid context")
+		return nil, errors.New("cannot get valid context")
 	}
 	if v != 1 {
-		return nil, fmt.Errorf("cannot get valid context")
+		return nil, errors.New("cannot get valid context")
 	}
 	return []byte("1"), nil
 }

--- a/scanner/context.go
+++ b/scanner/context.go
@@ -1,7 +1,7 @@
 package scanner
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 	"strings"
 	"sync"
@@ -127,7 +127,7 @@ func (c *Context) validateDocumentLineIndentColumn() error {
 		return nil
 	}
 	if c.docFirstLineIndentColumn > c.docLineIndentColumn {
-		return fmt.Errorf("invalid number of indent is specified in the document header")
+		return errors.New("invalid number of indent is specified in the document header")
 	}
 	return nil
 }


### PR DESCRIPTION
The PR replaces `fmt.Sprint.*` statements with faster alternatives suggested by the [`perfsprint`](https://golangci-lint.run/usage/linters/#perfsprint) linter:

- Replace `fmt.Sprint(v)` with `strconv.FormatInt(v, 10)`, where `v` is `int64`.
- Replace `fmt.Sprint(v)` with `strconv.FormatUint(v, 10)`, where `v` is `uint64`.
- Replace `fmt.Sprint(v)` with `strconv.FormatBool(v)`, where `v` is `bool`.
- Replace `fmt.Errorf(msg)` with `errors.New(msg)`.