### PR TITLE
Change YAMLToJSON to ToJSON, JSONToYAML to FromJSON

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,9 @@ linters-settings:
       - tests
   misspell:
     locale: US
+  revive:
+    rules:
+      - name: exported
   staticcheck:
     checks: ["all", "-ST1000", "-ST1005"]
 
@@ -31,6 +34,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - revive
     - staticcheck
     - typecheck
     - unused

--- a/decode.go
+++ b/decode.go
@@ -924,7 +924,7 @@ func (d *Decoder) decodeByUnmarshaler(ctx context.Context, dst reflect.Value, sr
 			if err != nil {
 				return err
 			}
-			jsonBytes, err := YAMLToJSON(b)
+			jsonBytes, err := ToJSON(b)
 			if err != nil {
 				return err
 			}

--- a/encode.go
+++ b/encode.go
@@ -410,7 +410,7 @@ func (e *Encoder) encodeByMarshaler(ctx context.Context, v reflect.Value, column
 			if err != nil {
 				return nil, err
 			}
-			doc, err := JSONToYAML(jsonBytes)
+			doc, err := FromJSON(jsonBytes)
 			if err != nil {
 				return nil, err
 			}

--- a/yaml.go
+++ b/yaml.go
@@ -220,8 +220,8 @@ func FormatError(e error, colored, inclSource bool) string {
 	return e.Error()
 }
 
-// YAMLToJSON convert YAML bytes to JSON.
-func YAMLToJSON(bytes []byte) ([]byte, error) {
+// ToJSON converts YAML bytes to JSON.
+func ToJSON(bytes []byte) ([]byte, error) {
 	var v interface{}
 	if err := UnmarshalWithOptions(bytes, &v, UseOrderedMap()); err != nil {
 		return nil, err
@@ -233,8 +233,8 @@ func YAMLToJSON(bytes []byte) ([]byte, error) {
 	return out, nil
 }
 
-// JSONToYAML convert JSON bytes to YAML.
-func JSONToYAML(bytes []byte) ([]byte, error) {
+// FromJSON converts JSON bytes to YAML.
+func FromJSON(bytes []byte) ([]byte, error) {
 	var v interface{}
 	if err := UnmarshalWithOptions(bytes, &v, UseOrderedMap()); err != nil {
 		return nil, err
@@ -244,6 +244,20 @@ func JSONToYAML(bytes []byte) ([]byte, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// YAMLToJSON converts YAML bytes to JSON.
+//
+// Deprecated: Use ToJSON instead.
+func YAMLToJSON(bytes []byte) ([]byte, error) { //nolint:revive // exported
+	return ToJSON(bytes)
+}
+
+// JSONToYAML convert JSON bytes to YAML.
+//
+// Deprecated: Use FromJSON instead.
+func JSONToYAML(bytes []byte) ([]byte, error) {
+	return FromJSON(bytes)
 }
 
 var (


### PR DESCRIPTION
The PR proposes renaming the functions `YAMLToJSON` to `ToJSON`, and `JSONToYAML` to `FromJSON` to avoid redundancies on the client side. For example, `yaml.ToJSON`, `yaml.FromJSON` are much simpler to use than `yaml.YAMLToJSON`, `yaml.JSONToYAML`.

This is suggested by the [`revive.exported`](https://golangci-lint.run/usage/linters/#revive) rule:

```
yaml.go:252:6: exported: func name will be used as yaml.YAMLToJSON by other packages, and that stutters; consider calling this ToJSON (revive)
func YAMLToJSON(bytes []byte) ([]byte, error) {
     ^
```