### PR TITLE
Fix panic when parsing unattached comment

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -152,6 +152,10 @@ func (p *parser) parseDocumentBody(ctx *context) (ast.Node, error) {
 }
 
 func (p *parser) parseToken(ctx *context, tk *Token) (ast.Node, error) {
+	if tk == nil {
+		return nil, nil
+	}
+
 	switch tk.GroupType() {
 	case TokenGroupMapKey, TokenGroupMapKeyValue:
 		return p.parseMap(ctx)
@@ -1063,7 +1067,12 @@ func (p *parser) parseDirective(ctx *context, g *TokenGroup) (*ast.DirectiveNode
 
 func (p *parser) parseComment(ctx *context) (ast.Node, error) {
 	cm := p.parseHeadComment(ctx)
-	node, err := p.parseToken(ctx, ctx.currentToken())
+	nextTok := ctx.currentToken()
+	if nextTok == nil {
+		return cm, nil
+	}
+
+	node, err := p.parseToken(ctx, nextTok)
 	if err != nil {
 		return nil, err
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1473,6 +1473,14 @@ foo: > # comment
   x: 42
 `,
 		},
+		{
+			name: "unattached comment",
+			yaml: `
+# This comment is in its own document
+---
+a: b
+`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
After the parser refactor, there's a panic when a comment exists on its own without anything to attach it to. This PR fixes that case.

Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification