### PR TITLE
Fix parsing of directive value

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1726,8 +1726,11 @@ func (n *AliasNode) MarshalYAML() ([]byte, error) {
 // DirectiveNode type of directive node
 type DirectiveNode struct {
 	*BaseNode
-	Start  *token.Token
-	Name   Node
+	// Start is '%' token.
+	Start *token.Token
+	// Name is directive name e.g.) "YAML" or "TAG".
+	Name Node
+	// Values is directive values e.g.) "1.2" or "!!" and "tag:clarkevans.com,2002:app/".
 	Values []Node
 }
 

--- a/decode.go
+++ b/decode.go
@@ -354,6 +354,16 @@ func (d *Decoder) nodeToValue(node ast.Node) (any, error) {
 	case *ast.NanNode:
 		return n.GetValue(), nil
 	case *ast.TagNode:
+		if n.Directive != nil {
+			v, err := d.nodeToValue(n.Value)
+			if err != nil {
+				return nil, err
+			}
+			if v == nil {
+				return "", nil
+			}
+			return fmt.Sprint(v), nil
+		}
 		switch token.ReservedTagKeyword(n.Start.Value) {
 		case token.TimestampTag:
 			t, _ := d.castToTime(n.Value)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -615,11 +615,17 @@ func (s *Scanner) scanWhiteSpace(ctx *Context) bool {
 	if ctx.isDocument() {
 		return false
 	}
-	if !s.isAnchor && !s.isAlias && !s.isFirstCharAtLine {
+	if !s.isAnchor && !s.isDirective && !s.isAlias && !s.isFirstCharAtLine {
 		return false
 	}
 
 	if s.isFirstCharAtLine {
+		s.progressColumn(ctx, 1)
+		ctx.addOriginBuf(' ')
+		return true
+	}
+	if s.isDirective {
+		s.addBufferedTokenIfExists(ctx)
 		s.progressColumn(ctx, 1)
 		ctx.addOriginBuf(' ')
 		return true
@@ -1176,7 +1182,9 @@ func (s *Scanner) scanDirective(ctx *Context) bool {
 		return false
 	}
 
-	ctx.addToken(token.Directive(string(ctx.obuf)+"%", s.pos()))
+	s.addBufferedTokenIfExists(ctx)
+	ctx.addOriginBuf('%')
+	ctx.addToken(token.Directive(string(ctx.obuf), s.pos()))
 	s.progressColumn(ctx, 1)
 	ctx.clear()
 	s.isDirective = true

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -662,7 +662,7 @@ func (s *Scanner) isMergeKey(ctx *Context) bool {
 }
 
 func (s *Scanner) scanTag(ctx *Context) bool {
-	if ctx.existsBuffer() {
+	if ctx.existsBuffer() || s.isDirective {
 		return false
 	}
 

--- a/yaml_test_suite_test.go
+++ b/yaml_test_suite_test.go
@@ -75,7 +75,6 @@ var failureTestNames = []string{
 	"spec-example-7-3-completely-empty-flow-nodes",          // no json.
 	"spec-example-8-18-implicit-block-mapping-entries",      // no json.
 	"spec-example-8-19-compact-block-mappings",              // no json.
-	"spec-example-6-24-verbatim-tags",                       // pass yamlv3.
 	"spec-example-6-6-line-folding",                         // pass yamlv3.
 	"spec-example-6-6-line-folding-1-3",                     // pass yamlv3.
 	"spec-example-6-8-flow-folding",                         // pass yamlv3.
@@ -99,7 +98,6 @@ var failureTestNames = []string{
 	"tabs-that-look-like-indentation/07",
 	"tabs-that-look-like-indentation/08", // pass yamlv3.
 	"tag-shorthand-used-in-documents-but-only-defined-in-the-first",
-	"tags-for-block-objects",                           // pass yamlv3.
 	"tags-on-empty-scalars",                            // no json.
 	"trailing-line-of-spaces/01",                       // last '\n' character is needed ?
 	"various-combinations-of-explicit-block-mappings",  // no json.

--- a/yaml_test_suite_test.go
+++ b/yaml_test_suite_test.go
@@ -18,14 +18,10 @@ var failureTestNames = []string{
 	"aliases-in-flow-objects",           // no json.
 	"aliases-in-explicit-block-mapping", // no json.
 	"block-mapping-with-missing-keys",   // no json.
-	"block-scalar-with-more-spaces-than-first-content-line",
 	"colon-at-the-beginning-of-adjacent-flow-scalar",
 	"comment-without-whitespace-after-doublequoted-scalar",
 	"construct-binary",
 	"dash-in-flow-sequence",
-	"double-quoted-scalar-with-escaped-single-quote",
-	"escaped-slash-in-double-quotes",
-	"explicit-key-and-value-seperated-by-comment",      //nolint: misspell // pass yamlv3.
 	"empty-implicit-key-in-single-pair-flow-sequences", // no json.
 	"empty-keys-in-block-and-flow-mapping",             // no json.
 	"empty-lines-at-end-of-document",                   // no json.
@@ -41,18 +37,15 @@ var failureTestNames = []string{
 	"invalid-comment-after-comma",
 	"invalid-comment-after-end-of-flow-sequence",
 	"invalid-comma-in-tag",
-	"invalid-tag",                                         // pass yamlv3.
-	"leading-tabs-in-double-quoted/02",                    // pass yamlv3.
-	"leading-tabs-in-double-quoted/05",                    // pass yamlv3.
-	"legal-tab-after-indentation",                         // pass yamlv3.
-	"literal-block-scalar-with-more-spaces-in-first-line", // pass yamlv3.
-	"literal-modifers/00",                                 // pass yamlv3.
-	"literal-modifers/01",                                 // pass yamlv3.
-	"literal-modifers/02",                                 // pass yamlv3.
-	"literal-modifers/03",                                 // pass yamlv3.
-	"literal-scalars",                                     // pass yamlv3.
-	"mapping-key-and-flow-sequence-item-anchors",          // no json.
-	"multiline-double-quoted-implicit-keys",               // pass yamlv3.
+	"invalid-tag",                                // pass yamlv3.
+	"legal-tab-after-indentation",                // pass yamlv3.
+	"literal-modifers/00",                        // pass yamlv3.
+	"literal-modifers/01",                        // pass yamlv3.
+	"literal-modifers/02",                        // pass yamlv3.
+	"literal-modifers/03",                        // pass yamlv3.
+	"literal-scalars",                            // pass yamlv3.
+	"mapping-key-and-flow-sequence-item-anchors", // no json.
+	"multiline-double-quoted-implicit-keys",      // pass yamlv3.
 	"multiline-plain-flow-mapping-key",
 	"multiline-plain-value-with-tabs-on-empty-lines", // pass yamlv3.
 	"multiline-scalar-at-top-level",                  // pass yamlv3.
@@ -65,7 +58,6 @@ var failureTestNames = []string{
 	"plain-url-in-flow-mapping",                             // pass yamlv3.
 	"question-mark-edge-cases/00",                           // no json.
 	"question-mark-edge-cases/01",                           // no json.
-	"scalar-doc-with-in-content/01",                         // pass yamlv3.
 	"scalar-value-with-two-anchors",                         // pass yamlv3.
 	"single-character-streams/01",                           // no json.
 	"single-pair-implicit-entries",                          // no json.
@@ -77,9 +69,7 @@ var failureTestNames = []string{
 	"spec-example-8-19-compact-block-mappings",              // no json.
 	"spec-example-6-6-line-folding",                         // pass yamlv3.
 	"spec-example-6-6-line-folding-1-3",                     // pass yamlv3.
-	"spec-example-6-8-flow-folding",                         // pass yamlv3.
 	"spec-example-8-10-folded-lines-8-13-final-empty-lines", // pass yamlv3.
-	"spec-example-8-17-explicit-block-mapping-entries",      // pass yamlv3.
 	"spec-example-8-2-block-indentation-indicator",
 	"spec-example-9-3-bare-documents",
 	"spec-example-9-4-explicit-documents",
@@ -91,12 +81,10 @@ var failureTestNames = []string{
 	"tabs-in-various-contexts/003",
 	"tabs-that-look-like-indentation/00",
 	"tabs-that-look-like-indentation/01",
-	"tabs-that-look-like-indentation/02", // pass yamlv3.
 	"tabs-that-look-like-indentation/03",
 	"tabs-that-look-like-indentation/04",
 	"tabs-that-look-like-indentation/05", // pass yamlv3.
 	"tabs-that-look-like-indentation/07",
-	"tabs-that-look-like-indentation/08", // pass yamlv3.
 	"tag-shorthand-used-in-documents-but-only-defined-in-the-first",
 	"tags-on-empty-scalars",                            // no json.
 	"trailing-line-of-spaces/01",                       // last '\n' character is needed ?

--- a/yaml_test_suite_test.go
+++ b/yaml_test_suite_test.go
@@ -23,13 +23,9 @@ var failureTestNames = []string{
 	"comment-without-whitespace-after-doublequoted-scalar",
 	"construct-binary",
 	"dash-in-flow-sequence",
-	"directive-variants/00",
-	"directive-variants/01", // pass yamlv3.
 	"double-quoted-scalar-with-escaped-single-quote",
-	"duplicate-yaml-directive", // pass yamlv3.
 	"escaped-slash-in-double-quotes",
 	"explicit-key-and-value-seperated-by-comment",      //nolint: misspell // pass yamlv3.
-	"extra-words-on-yaml-directive",                    // pass yamlv3.
 	"empty-implicit-key-in-single-pair-flow-sequences", // no json.
 	"empty-keys-in-block-and-flow-mapping",             // no json.
 	"empty-lines-at-end-of-document",                   // no json.
@@ -79,7 +75,6 @@ var failureTestNames = []string{
 	"spec-example-7-3-completely-empty-flow-nodes",          // no json.
 	"spec-example-8-18-implicit-block-mapping-entries",      // no json.
 	"spec-example-8-19-compact-block-mappings",              // no json.
-	"spec-example-6-19-secondary-tag-handle",                // pass yamlv3.
 	"spec-example-6-24-verbatim-tags",                       // pass yamlv3.
 	"spec-example-6-6-line-folding",                         // pass yamlv3.
 	"spec-example-6-6-line-folding-1-3",                     // pass yamlv3.


### PR DESCRIPTION
### Breaking Changes

`ast.DirectiveNode` has the `Name` and `Values` field.
- `Name`: directive name e.g.) `YAML` or `TAG`
- `Values` : directive values e.g.) `1.2` or `!!` `tag:clarkevans.com,2002:app/`