### PR TITLE
fix typo in CharacterType

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -217,7 +217,7 @@ func (c CharacterType) String() string {
 	case CharacterTypeIndicator:
 		return "Indicator"
 	case CharacterTypeWhiteSpace:
-		return "WhiteSpcae"
+		return "WhiteSpace"
 	case CharacterTypeMiscellaneous:
 		return "Miscellaneous"
 	case CharacterTypeEscaped:


### PR DESCRIPTION
fix typo in `token/token.go`:

- `WhiteSpcae` -> `WhiteSpace`