### PR TITLE
Fix displaying testable example on pkg.go.dev

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1999,7 +1999,7 @@ w: w_value
 	}
 }
 
-func Example_YAMLTags() {
+func ExampleUnmarshal_yAMLTags() {
 	yml := `---
 foo: 1
 bar: c
@@ -2179,7 +2179,7 @@ map: &map
 	})
 }
 
-func Example_JSONTags() {
+func ExampleUnmarshal_jSONTags() {
 	yml := `---
 foo: 1
 bar: c
@@ -2198,7 +2198,7 @@ bar: c
 	// c
 }
 
-func Example_DisallowUnknownField() {
+func ExampleDecoder_Decode_disallowUnknownField() {
 	var v struct {
 		A string `yaml:"simple"`
 		C string `yaml:"complicated"`
@@ -2219,7 +2219,7 @@ unknown: string
 	//        ^
 }
 
-func Example_Unmarshal_Node() {
+func ExampleNodeToValue() {
 	f, err := parser.ParseBytes([]byte("text: node example"), 0)
 	if err != nil {
 		panic(err)

--- a/encode_test.go
+++ b/encode_test.go
@@ -1289,7 +1289,7 @@ func TestEncoder_MultipleDocuments(t *testing.T) {
 	}
 }
 
-func Example_Marshal_Node() {
+func ExampleMarshal_node() {
 	type T struct {
 		Text ast.Node `yaml:"text"`
 	}
@@ -1306,7 +1306,7 @@ func Example_Marshal_Node() {
 	// text: node example
 }
 
-func Example_Marshal_ExplicitAnchorAlias() {
+func ExampleMarshal_explicitAnchorAlias() {
 	type T struct {
 		A int
 		B string
@@ -1329,7 +1329,7 @@ func Example_Marshal_ExplicitAnchorAlias() {
 	// d: *x
 }
 
-func Example_Marshal_ImplicitAnchorAlias() {
+func ExampleMarshal_implicitAnchorAlias() {
 	type T struct {
 		I int
 		S string
@@ -1454,7 +1454,7 @@ func (t TextMarshaler) MarshalText() ([]byte, error) {
 	return []byte(strconv.FormatInt(int64(t), 8)), nil
 }
 
-func Example_MarshalYAML() {
+func ExampleMarshal() {
 	var slow SlowMarshaler
 	slow.A = "Hello slow poke"
 	slow.B = 100

--- a/path_test.go
+++ b/path_test.go
@@ -634,7 +634,7 @@ b: "hello"
 	//    3 | b: "hello"
 }
 
-func ExamplePath_AnnotateSourceWithComment() {
+func ExamplePath_AnnotateSource_withComment() {
 	yml := `
 # This is my document
 doc:
@@ -664,7 +664,7 @@ doc:
 	//    9 |   other: value3
 }
 
-func ExamplePath_PathString() {
+func ExamplePathString() {
 	yml := `
 store:
   book:


### PR DESCRIPTION
Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification

The repo contains 11 testable examples, but on the https://pkg.go.dev/github.com/goccy/go-yaml@v1.15.9#pkg-examples there is only 1 example listed. This PR fixes that all examples will be listed after merging.

Before:

<img width="379" alt="image" src="https://github.com/user-attachments/assets/1de1aa23-fb66-4212-808b-b01d857d49f3" />

After:

<img width="457" alt="image" src="https://github.com/user-attachments/assets/8eff0a70-7233-4a28-b6df-4f6fe569e095" />

Explanation https://go.dev/blog/examples#example-function-names