### PR TITLE
Refactor unexported funcs by removing unnecessary error result

### DIFF
--- a/parser/node.go
+++ b/parser/node.go
@@ -8,10 +8,10 @@ import (
 	"github.com/goccy/go-yaml/token"
 )
 
-func newMappingNode(ctx *context, tk *Token, isFlow bool, values ...*ast.MappingValueNode) (*ast.MappingNode, error) {
+func newMappingNode(ctx *context, tk *Token, isFlow bool, values ...*ast.MappingValueNode) *ast.MappingNode {
 	node := ast.Mapping(tk.RawToken(), isFlow, values...)
 	node.SetPath(ctx.path)
-	return node, nil
+	return node
 }
 
 func newMappingValueNode(ctx *context, tk *Token, key ast.MapKeyNode, value ast.Node) (*ast.MappingValueNode, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -327,10 +327,7 @@ func (p *parser) parseScalarValue(ctx *context, tk *Token) (ast.ScalarNode, erro
 }
 
 func (p *parser) parseFlowMap(ctx *context) (*ast.MappingNode, error) {
-	node, err := newMappingNode(ctx, ctx.currentToken(), true)
-	if err != nil {
-		return nil, err
-	}
+	node := newMappingNode(ctx, ctx.currentToken(), true)
 	ctx.goNext() // skip MappingStart token
 
 	isFirst := true
@@ -466,10 +463,7 @@ func (p *parser) parseMap(ctx *context) (*ast.MappingNode, error) {
 		}
 		keyValueNode = node
 	}
-	mapNode, err := newMappingNode(ctx, &Token{Token: keyValueNode.GetToken()}, false, keyValueNode)
-	if err != nil {
-		return nil, err
-	}
+	mapNode := newMappingNode(ctx, &Token{Token: keyValueNode.GetToken()}, false, keyValueNode)
 	var tk *Token
 	if ctx.isComment() {
 		tk = ctx.nextNotCommentToken()

--- a/parser/token.go
+++ b/parser/token.go
@@ -205,10 +205,7 @@ func createGroupedTokens(tokens token.Tokens) ([]*Token, error) {
 	var err error
 	tks := newTokens(tokens)
 	tks = createLineCommentTokenGroups(tks)
-	tks, err = createLiteralAndFoldedTokenGroups(tks)
-	if err != nil {
-		return nil, err
-	}
+	tks = createLiteralAndFoldedTokenGroups(tks)
 	tks, err = createAnchorAndAliasTokenGroups(tks)
 	if err != nil {
 		return nil, err
@@ -260,7 +257,7 @@ func createLineCommentTokenGroups(tokens []*Token) []*Token {
 	return ret
 }
 
-func createLiteralAndFoldedTokenGroups(tokens []*Token) ([]*Token, error) {
+func createLiteralAndFoldedTokenGroups(tokens []*Token) []*Token {
 	ret := make([]*Token, 0, len(tokens))
 	for i := 0; i < len(tokens); i++ {
 		tk := tokens[i]
@@ -293,7 +290,7 @@ func createLiteralAndFoldedTokenGroups(tokens []*Token) ([]*Token, error) {
 			ret = append(ret, tk)
 		}
 	}
-	return ret, nil
+	return ret
 }
 
 func createAnchorAndAliasTokenGroups(tokens []*Token) ([]*Token, error) {


### PR DESCRIPTION
Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification

The PR removes `error` result from `newMappingNode` and `createLiteralAndFoldedTokenGroups` functions as it is always `nil`. This increases code coverage and removes unreachable paths.