### PR TITLE
Remove mention of removed option DisallowDuplicateKey

### DIFF
--- a/option.go
+++ b/option.go
@@ -50,7 +50,7 @@ func Validator(v StructValidator) DecodeOption {
 	}
 }
 
-// Strict enable DisallowUnknownField and DisallowDuplicateKey
+// Strict enable DisallowUnknownField
 func Strict() DecodeOption {
 	return func(d *Decoder) error {
 		d.disallowUnknownField = true


### PR DESCRIPTION
Remove mention of the removed option `DisallowDuplicateKey`, which was removed in https://github.com/goccy/go-yaml/pull/531.

I almost feel bad for making such a silly PR but it's right there and can't help it 😬.
