### PR TITLE
fix(parser): inconsistent paths single-line MappingKeyValueNode

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -561,11 +561,13 @@ func (p *parser) parseMapKeyValue(ctx *context, g *TokenGroup) (*ast.MappingValu
 	if err != nil {
 		return nil, err
 	}
-	value, err := p.parseToken(ctx.withChild(p.mapKeyText(key)), g.Last())
+
+	c := ctx.withChild(p.mapKeyText(key))
+	value, err := p.parseToken(c, g.Last())
 	if err != nil {
 		return nil, err
 	}
-	return newMappingValueNode(ctx, keyGroup.Last(), key, value)
+	return newMappingValueNode(c, keyGroup.Last(), key, value)
 }
 
 func (p *parser) parseMapKey(ctx *context, g *TokenGroup) (ast.MapKeyNode, error) {


### PR DESCRIPTION
Fixes #583 

I am writing a YAML transformer and this path inconsistency was standing in my way.

I am not sure how to extend the current test suite for this fix.