### PR TITLE
issue-281: add tests and fix panic for *

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin/
 cover.out
+.DS_Store
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 bin/
 cover.out
-.DS_Store
-.idea/

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1598,6 +1598,9 @@ func (n *SequenceNode) blockStyleString() string {
 	}
 
 	for idx, value := range n.Values {
+		if value == nil {
+			continue
+		}
 		valueStr := value.String()
 		newLinePrefix := ""
 		if strings.HasPrefix(valueStr, "\n") {


### PR DESCRIPTION
Before submitting your PR, please confirm the following.

partially resolves #281 

- added tests
- fixed null pointer panic with nill guard
- while the incorrect behaviour for some paths lookup remains unfixed, a test has been added to reproduce and highlight this issue.

- [X] Describe the purpose for which you created this PR.  
- [X] Create test code that corresponds to the modification