### PR TITLE
refactor: remove unused Anchor field from MappingValueNode

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1350,7 +1350,6 @@ type MappingValueNode struct {
 	Start       *token.Token
 	Key         MapKeyNode
 	Value       Node
-	Anchor      *AnchorNode
 	FootComment *CommentGroupNode
 }
 


### PR DESCRIPTION
This PR simplifies the `MappingValueNode` structure by removing the unused `Anchor` field

- [x] Describe the purpose for which you created this PR.  
- [ ] Create test code that corresponds to the modification