### PR TITLE
feat: support receiving ast.Node in custom unmarshalers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
+.idea/
 cover.out

--- a/decode.go
+++ b/decode.go
@@ -846,19 +846,15 @@ func (d *Decoder) canDecodeByUnmarshaler(dst reflect.Value) bool {
 	}
 	iface := ptrValue.Interface()
 	switch iface.(type) {
-	case BytesUnmarshalerContext:
-		return true
-	case BytesUnmarshaler:
-		return true
-	case InterfaceUnmarshalerContext:
-		return true
-	case InterfaceUnmarshaler:
-		return true
-	case *time.Time:
-		return true
-	case *time.Duration:
-		return true
-	case encoding.TextUnmarshaler:
+	case BytesUnmarshalerContext,
+		BytesUnmarshaler,
+		InterfaceUnmarshalerContext,
+		InterfaceUnmarshaler,
+		NodeUnmarshaler,
+		NodeUnmarshalerContext,
+		*time.Time,
+		*time.Duration,
+		encoding.TextUnmarshaler:
 		return true
 	case jsonUnmarshaler:
 		return d.useJSONUnmarshaler
@@ -931,6 +927,22 @@ func (d *Decoder) decodeByUnmarshaler(ctx context.Context, dst reflect.Value, sr
 		}); err != nil {
 			return err
 		}
+		return nil
+	}
+
+	if unmarshaler, ok := iface.(NodeUnmarshaler); ok {
+		if err := unmarshaler.UnmarshalYAML(src); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if unmarshaler, ok := iface.(NodeUnmarshalerContext); ok {
+		if err := unmarshaler.UnmarshalYAML(ctx, src); err != nil {
+			return err
+		}
+
 		return nil
 	}
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -3131,6 +3131,182 @@ func (mk *unmarshableMapKey) UnmarshalYAML(b []byte) error {
 	return nil
 }
 
+type testNodeUnmarshalerCtx struct {
+	outErr   error
+	received ast.Node
+}
+
+func (u *testNodeUnmarshalerCtx) UnmarshalYAML(ctx context.Context, node ast.Node) error {
+	if u.outErr != nil {
+		return u.outErr
+	}
+
+	if ctx == nil {
+		return errors.New("nil context")
+	}
+
+	u.received = node
+	return nil
+}
+
+func TestNodeUnmarshalerContext(t *testing.T) {
+	type testNodeUnmarshalerBody struct {
+		Root testNodeUnmarshalerCtx `yaml:"root"`
+	}
+
+	cases := []struct {
+		name      string
+		expectErr string
+		src       []string
+		body      testNodeUnmarshalerBody
+	}{
+		{
+			name: "should pass node",
+			src: []string{
+				"root:",
+				"  foo: bar",
+				"  fizz: buzz",
+			},
+		},
+		{
+			name: "should pass returned error",
+			body: testNodeUnmarshalerBody{
+				Root: testNodeUnmarshalerCtx{
+					outErr: errors.New("test error"),
+				},
+			},
+			expectErr: "test error",
+			src: []string{
+				"root:",
+				"  foo: bar",
+				"  fizz: buzz",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			src := []byte(strings.Join(c.src, "\n"))
+			out := c.body
+			err := yaml.Unmarshal(src, &out)
+			if c.expectErr != "" {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+					return
+				}
+
+				if !strings.Contains(err.Error(), c.expectErr) {
+					t.Fatalf("error message %q should contain %q", err.Error(), c.expectErr)
+				}
+				return
+			}
+
+			expect := struct {
+				Root ast.Node `yaml:"root"`
+			}{}
+			if err := yaml.UnmarshalContext(context.TODO(), src, &expect); err != nil {
+				t.Fatal("invalid test yaml:", err)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !reflect.DeepEqual(out.Root.received, expect.Root) {
+				t.Fatalf("expected:\n%#v\n but got:\n%#v", expect.Root, out.Root.received)
+			}
+		})
+	}
+
+}
+
+type testNodeUnmarshaler struct {
+	outErr   error
+	received ast.Node
+}
+
+func (u *testNodeUnmarshaler) UnmarshalYAML(node ast.Node) error {
+	if u.outErr != nil {
+		return u.outErr
+	}
+
+	u.received = node
+	return nil
+}
+
+func TestNodeUnmarshaler(t *testing.T) {
+	type testNodeUnmarshalerBody struct {
+		Root testNodeUnmarshaler `yaml:"root"`
+	}
+
+	cases := []struct {
+		name      string
+		expectErr string
+		src       []string
+		body      testNodeUnmarshalerBody
+	}{
+		{
+			name: "should pass node",
+			src: []string{
+				"root:",
+				"  foo: bar",
+				"  fizz: buzz",
+			},
+		},
+		{
+			name: "should pass returned error",
+			body: testNodeUnmarshalerBody{
+				Root: testNodeUnmarshaler{
+					outErr: errors.New("test error"),
+				},
+			},
+			expectErr: "test error",
+			src: []string{
+				"root:",
+				"  foo: bar",
+				"  fizz: buzz",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			src := []byte(strings.Join(c.src, "\n"))
+			out := c.body
+			err := yaml.Unmarshal(src, &out)
+			if c.expectErr != "" {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+					return
+				}
+
+				if !strings.Contains(err.Error(), c.expectErr) {
+					t.Fatalf("error message %q should contain %q", err.Error(), c.expectErr)
+				}
+				return
+			}
+
+			expect := struct {
+				Root ast.Node `yaml:"root"`
+			}{}
+			if err := yaml.Unmarshal(src, &expect); err != nil {
+				t.Fatal("invalid test yaml:", err)
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !reflect.DeepEqual(out.Root.received, expect.Root) {
+				t.Fatalf("expected:\n%#v\n but got:\n%#v", expect.Root, out.Root.received)
+			}
+		})
+	}
+
+}
+
 func TestMapKeyCustomUnmarshaler(t *testing.T) {
 	var m map[unmarshableMapKey]string
 	if err := yaml.Unmarshal([]byte(`key: value`), &m); err != nil {

--- a/yaml.go
+++ b/yaml.go
@@ -57,6 +57,16 @@ type InterfaceUnmarshalerContext interface {
 	UnmarshalYAML(context.Context, func(interface{}) error) error
 }
 
+// NodeUnmarshaler interface is similar to BytesUnmarshaler but provide related AST node instead of raw YAML source.
+type NodeUnmarshaler interface {
+	UnmarshalYAML(ast.Node) error
+}
+
+// NodeUnmarshalerContext interface is similar to BytesUnmarshaler but provide related AST node instead of raw YAML source.
+type NodeUnmarshalerContext interface {
+	UnmarshalYAML(context.Context, ast.Node) error
+}
+
 // MapItem is an item in a MapSlice.
 type MapItem struct {
 	Key, Value interface{}


### PR DESCRIPTION
The `go-yaml` library in addition to custom unmarshalers, also allows partial unmarshaling into `ast.Node` struct members.\
This can be useful when working with dynamic documents.

Unfortunately this is not enough when there is a need to have a custom type which needs to be constructed out of `ast.Node` but you also would like to avoid inner unmarshaling inside `TextUnmarshaler`.

In my case, this is also useful in order to provide a detailed information about position in returned syntax error.

### Use-case demo

Let's assume you've an application which can accept some dynamic value which needs to be validated later.

Application accepts an input something like this:

```yaml
tasks:
  build:
    - action: foo
      timeout: 10s
      with:
        # Here is a dynamic content
        key: value
        items:
          - 1
          - ${foo.bar.baz} # App supports might want to pre-process some fields
          - true
```

Most of the content is static except `tasks.[*].with` which can have different body depending on context.\
Currently in order to process that, you would need to unmarshal whole document into a struct below and process `ast.Node` fields separately.

```go
type Doc struct {
	Tasks map[string]struct{
		Action string
		With ast.Node
	}
}
```

This PR introduces `NodeUnmarshaler` and `NodeUnmarshalerContext` interfaces that allow moving AST traversal into an unmarshaler.

### Testing

I've added tests for both new interfaces into `yaml_test.go`
