### PR TITLE
Make UseSingleQuote compliant with the YAML spec

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -704,7 +704,7 @@ func TestEncoder(t *testing.T) {
 		},
 		// Quote style
 		{
-			`v: '\'a\'b'` + "\n",
+			`v: '''a''b'` + "\n",
 			map[string]string{"v": `'a'b`},
 			[]yaml.EncodeOption{
 				yaml.UseSingleQuote(true),
@@ -715,6 +715,20 @@ func TestEncoder(t *testing.T) {
 			map[string]string{"v": `'a'b`},
 			[]yaml.EncodeOption{
 				yaml.UseSingleQuote(false),
+			},
+		},
+		{
+			// Might be obvious but in case you are confused.
+			//
+			// Here, \ is doubled like \\ in test.source and test.value, only because they are Go string literals.
+			// This is testing that a slash is encoded as-is, without escaping.
+			// In the YAML spec, the only escape sequence is '', which represents a single quote.
+			// \\, \n, \t, or whatever you might expect YAML, Go strings, and Go strconv.Quote() to escape using the extra backslash,
+			// are not escaped and printed as-is in the YAML single-quoted string.
+			"a: '\\.yaml'" + "\n",
+			map[string]string{"a": "\\.yaml"},
+			[]yaml.EncodeOption{
+				yaml.UseSingleQuote(true),
 			},
 		},
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -718,15 +718,8 @@ func TestEncoder(t *testing.T) {
 			},
 		},
 		{
-			// Might be obvious but in case you are confused.
-			//
-			// Here, \ is doubled like \\ in test.source and test.value, only because they are Go string literals.
-			// This is testing that a slash is encoded as-is, without escaping.
-			// In the YAML spec, the only escape sequence is '', which represents a single quote.
-			// \\, \n, \t, or whatever you might expect YAML, Go strings, and Go strconv.Quote() to escape using the extra backslash,
-			// are not escaped and printed as-is in the YAML single-quoted string.
-			"a: '\\.yaml'" + "\n",
-			map[string]string{"a": "\\.yaml"},
+			`a: '\.yaml'` + "\n",
+			map[string]string{"a": `\.yaml`},
 			[]yaml.EncodeOption{
 				yaml.UseSingleQuote(true),
 			},

--- a/stdlib_quote.go
+++ b/stdlib_quote.go
@@ -53,8 +53,18 @@ func appendQuotedWith(buf []byte, s string, quote byte) []byte {
 
 func appendEscapedRune(buf []byte, r rune, quote byte) []byte {
 	var runeTmp [utf8.UTFMax]byte
-	if r == rune(quote) || r == '\\' { // always backslashed
-		buf = append(buf, '\\')
+	// goccy/go-yaml patch on top of the standard library's appendEscapedRune function.
+	//
+	// We use this to implement the YAML single-quoted string, where the only escape sequence is '', which represents a single quote.
+	// The below snippet from the standard library is for escaping e.g. \ with \\, which is not what we want for the single-quoted string.
+	//
+	// if r == rune(quote) || r == '\\' { // always backslashed
+	// 	buf = append(buf, '\\')
+	// 	buf = append(buf, byte(r))
+	// 	return buf
+	// }
+	if r == rune(quote) {
+		buf = append(buf, byte(r))
 		buf = append(buf, byte(r))
 		return buf
 	}


### PR DESCRIPTION
Fixes #643

This follows-up on #265 to fix how single-quoted strings are encoded.

That is, the only escape-sequence in a single-quoted string is now `''` which represents `'` literally.

Previously, it treated whatever starting with `\` as a escape sequence, which is incorrect in a single-quoted string.
That resulted in encoding `\.` as `\\.` for example, that broke my use-case.
It's not YAML-compliant anyway so I believe making go-yaml compliant fixes my use-case too.

---

Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR. 
  - See above
- [x] Create test code that corresponds to the modification
  - See the updated `enmcoded_test.go` 
