### PR TITLE
Allow customizing the error message

### DIFF
--- a/error.go
+++ b/error.go
@@ -25,6 +25,7 @@ type (
 	DuplicateKeyError       = errors.DuplicateKeyError
 	UnknownFieldError       = errors.UnknownFieldError
 	UnexpectedNodeTypeError = errors.UnexpectedNodeTypeError
+	ErrorWithSource         = errors.ErrorWithSource
 )
 
 func ErrUnsupportedHeadPositionType(node ast.Node) error {

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -25,6 +25,10 @@ type PrettyFormatError interface {
 	FormatError(bool, bool) string
 }
 
+type ErrorWithSource interface {
+	WithMessage(string) error
+}
+
 type SyntaxError struct {
 	Message string
 	Token   *token.Token
@@ -117,12 +121,20 @@ func (e *SyntaxError) FormatError(colored, inclSource bool) string {
 	return formatError(e.Message, e.Token, colored, inclSource)
 }
 
+func (e *SyntaxError) WithMessage(msg string) error {
+	return ErrSyntax(msg, e.Token)
+}
+
 func (e *OverflowError) Error() string {
 	return e.FormatError(defaultFormatColor, defaultIncludeSource)
 }
 
 func (e *OverflowError) FormatError(colored, inclSource bool) string {
 	return formatError(fmt.Sprintf("cannot unmarshal %s into Go value of type %s ( overflow )", e.SrcNum, e.DstType), e.Token, colored, inclSource)
+}
+
+func (e *OverflowError) WithMessage(msg string) error {
+	return ErrSyntax(msg, e.Token)
 }
 
 func (e *TypeError) msg() string {
@@ -140,12 +152,20 @@ func (e *TypeError) FormatError(colored, inclSource bool) string {
 	return formatError(e.msg(), e.Token, colored, inclSource)
 }
 
+func (e *TypeError) WithMessage(msg string) error {
+	return ErrSyntax(msg, e.Token)
+}
+
 func (e *DuplicateKeyError) Error() string {
 	return e.FormatError(defaultFormatColor, defaultIncludeSource)
 }
 
 func (e *DuplicateKeyError) FormatError(colored, inclSource bool) string {
 	return formatError(e.Message, e.Token, colored, inclSource)
+}
+
+func (e *DuplicateKeyError) WithMessage(msg string) error {
+	return ErrSyntax(msg, e.Token)
 }
 
 func (e *UnknownFieldError) Error() string {
@@ -156,12 +176,20 @@ func (e *UnknownFieldError) FormatError(colored, inclSource bool) string {
 	return formatError(e.Message, e.Token, colored, inclSource)
 }
 
+func (e *UnknownFieldError) WithMessage(msg string) error {
+	return ErrSyntax(msg, e.Token)
+}
+
 func (e *UnexpectedNodeTypeError) Error() string {
 	return e.FormatError(defaultFormatColor, defaultIncludeSource)
 }
 
 func (e *UnexpectedNodeTypeError) FormatError(colored, inclSource bool) string {
 	return formatError(fmt.Sprintf("%s was used where %s is expected", e.Actual.YAMLName(), e.Expected.YAMLName()), e.Token, colored, inclSource)
+}
+
+func (e *UnexpectedNodeTypeError) WithMessage(msg string) error {
+	return ErrSyntax(msg, e.Token)
 }
 
 func formatError(errMsg string, token *token.Token, colored, inclSource bool) string {

--- a/internal/errors/error_test.go
+++ b/internal/errors/error_test.go
@@ -1,0 +1,27 @@
+package errors
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/goccy/go-yaml/token"
+)
+
+func TestErrorWithMessage(t *testing.T) {
+	tok := token.New("foo", "foo", &token.Position{})
+	errs := []ErrorWithSource{
+		ErrSyntax("original message", tok),
+		ErrOverflow(reflect.TypeOf(0), "1", tok),
+		ErrTypeMismatch(reflect.TypeOf(0), reflect.TypeOf(""), tok),
+		ErrDuplicateKey("original message", tok),
+		ErrUnknownField("original message", tok),
+		ErrUnexpectedNodeType(0, 1, tok),
+	}
+	want := "[0:0] new message\n>  0 | foo\n      ^\n"
+	for _, err := range errs {
+		got := err.WithMessage("new message").Error()
+		if got != want {
+			t.Fatalf("unexpected error message: %s, wanted: %s", got, want)
+		}
+	}
+}


### PR DESCRIPTION
This package produces really nice error messages that helpfully point to a section of YAML that caused an error. When there's an error, the package has technical knowledge of what the problem is. The calling program may have more practical knowledge of what the problem is, allowing it to present a helpful message to the user. In this case, it can be useful to allow that calling program to modify the message, but keep the portion of the error that points at the YAML source. Adding this interface allows it to do so in a consistent way that's agnostic of the exact underlying error type.

```go
func (o *SomeType) UnmarshalYAML(unmarshal func(interface{}) error) error {
  ...
  if err := unmarshal(&var); err != nil {
    if e, ok := err.(yaml.ErrorWithSource); ok {
      return e.WithMessage("Options for this field are ...")
    }
    return err
  }
  ...
}
```

Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification