### PR TITLE
Support smart anchor option

### DIFF
--- a/option.go
+++ b/option.go
@@ -143,6 +143,18 @@ func Flow(isFlowStyle bool) EncodeOption {
 	}
 }
 
+// WithSmartAnchor when multiple map values share the same pointer,
+// an anchor is automatically assigned to the first occurrence, and aliases are used for subsequent elements.
+// The map key name is used as the anchor name by default.
+// If key names conflict, a suffix is automatically added to avoid collisions.
+// This is an experimental feature and cannot be used simultaneously with anchor tags.
+func WithSmartAnchor() EncodeOption {
+	return func(e *Encoder) error {
+		e.enableSmartAnchor = true
+		return nil
+	}
+}
+
 // UseLiteralStyleIfMultiline causes encoding multiline strings with a literal syntax,
 // no matter what characters they include
 func UseLiteralStyleIfMultiline(useLiteralStyleIfMultiline bool) EncodeOption {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -98,3 +98,134 @@ d: &d [*c,*c]
 		}
 	}
 }
+
+func TestSmartAnchor(t *testing.T) {
+	var data = `
+a: &a [_,_,_,_,_,_,_,_,_,_,_,_,_,_,_]
+b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a,*a]
+c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b,*b]
+d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c,*c]
+e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d,*d]
+f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e,*e]
+g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f,*f]
+h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g,*g]
+i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h,*h]
+`
+	var v any
+	if err := yaml.Unmarshal([]byte(data), &v); err != nil {
+		t.Fatal(err)
+	}
+	got, err := yaml.MarshalWithOptions(v, yaml.WithSmartAnchor())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `
+a: &a
+- _
+- _
+- _
+- _
+- _
+- _
+- _
+- _
+- _
+- _
+- _
+- _
+- _
+- _
+- _
+b: &b
+- *a
+- *a
+- *a
+- *a
+- *a
+- *a
+- *a
+- *a
+- *a
+- *a
+c: &c
+- *b
+- *b
+- *b
+- *b
+- *b
+- *b
+- *b
+- *b
+- *b
+- *b
+d: &d
+- *c
+- *c
+- *c
+- *c
+- *c
+- *c
+- *c
+- *c
+- *c
+- *c
+e: &e
+- *d
+- *d
+- *d
+- *d
+- *d
+- *d
+- *d
+- *d
+- *d
+- *d
+f: &f
+- *e
+- *e
+- *e
+- *e
+- *e
+- *e
+- *e
+- *e
+- *e
+- *e
+g: &g
+- *f
+- *f
+- *f
+- *f
+- *f
+- *f
+- *f
+- *f
+- *f
+- *f
+h: &h
+- *g
+- *g
+- *g
+- *g
+- *g
+- *g
+- *g
+- *g
+- *g
+- *g
+i:
+- *h
+- *h
+- *h
+- *h
+- *h
+- *h
+- *h
+- *h
+- *h
+- *h
+`
+	if strings.TrimPrefix(expected, "\n") != string(got) {
+		t.Fatalf("failed to encode: %s", string(got))
+	}
+}


### PR DESCRIPTION
`yaml.WithSmartAnchor()` option automatically assigns an anchor name to a value when the same pointer address is found during encoding and uses an alias for reference points

ref #606 