### PR TITLE
feat: Dont make copies of structs for validation

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1425,7 +1425,13 @@ func (d *Decoder) decodeStruct(ctx context.Context, dst reflect.Value, src ast.N
 	}
 
 	if d.validator != nil {
-		if err := d.validator.Struct(dst.Interface()); err != nil {
+		var err error
+		if dst.CanAddr() {
+			err = d.validator.Struct(dst.Addr().Interface())
+		} else {
+			err = d.validator.Struct(dst.Interface())
+		}
+		if err != nil {
 			ev := reflect.ValueOf(err)
 			if ev.Type().Kind() == reflect.Slice {
 				for i := 0; i < ev.Len(); i++ {


### PR DESCRIPTION
This PR fixes a small problem with validation implementation:
Current implementation uses `dst.Interface()` which returns a value(`T`), not a pointer(`*T`) of a struct `T`. This can be a performance hit on bigger structures as compiler would have to partially copy the struct `T`. And since validation is performed on each structure, the whole thing would be copied at least N times (where N is the structure depth).

Passing by value also does not play nicely with other (non-reflection based) validation libraries, such as [`github.com/go-ozzo/ozzo-validation`](github.com/go-ozzo/ozzo-validation), since validating a structure there can require a method call, which is not possible. Converting an `interface{}` with value is not an option also - `reflect.Value.Addr()` is prohibited for `Value`s, created via `reflect.ValueOf(v)`.