### PR TITLE
Fix CommentGroupNode.Type()

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2074,7 +2074,7 @@ func (n *CommentGroupNode) Read(p []byte) (int, error) {
 }
 
 // Type returns TagType
-func (n *CommentGroupNode) Type() NodeType { return CommentType }
+func (n *CommentGroupNode) Type() NodeType { return CommentGroupType }
 
 // GetToken returns token instance
 func (n *CommentGroupNode) GetToken() *token.Token {


### PR DESCRIPTION
CommentGroupNode.Type() should return **CommentGroupType** instead of **CommentType** .