### PR TITLE
add an encoding option to force string value quoting

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -724,6 +724,14 @@ func TestEncoder(t *testing.T) {
 				yaml.UseSingleQuote(true),
 			},
 		},
+		// Forced string value quoting
+		{
+			`foo: "a b c"` + "\n",
+			map[string]string{"foo": "a b c"},
+			[]yaml.EncodeOption{
+				yaml.QuoteStringValues(true),
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.source, func(t *testing.T) {

--- a/option.go
+++ b/option.go
@@ -127,6 +127,14 @@ func IndentSequence(indent bool) EncodeOption {
 	}
 }
 
+// QuoteStringValues causes all string values to be quoted.
+func QuoteStringValues(quote bool) EncodeOption {
+	return func(e *Encoder) error {
+		e.quoteStringValues = quote
+		return nil
+	}
+}
+
 // UseSingleQuote determines if single or double quotes should be preferred for strings.
 func UseSingleQuote(sq bool) EncodeOption {
 	return func(e *Encoder) error {


### PR DESCRIPTION
The current encoder does not quote strings (with very few exceptions):
```yaml
foo: a b c
bar: xzy
baz: "true"
```

While this is perfectly valid YAML, it can be inconsistent and hard to read. A common convention is to always quote string values. With the previous example:
```yaml
foo: "a b c"
bar: "xzy"
baz: "true"
```

Quoting keys is unnecessary, and this presentation is both consistent and easy to read.

This patch adds an encoding option that always quotes string values. Hopefully I understood the calls to encodeString correctly! Of course it would be possible to add a quoteStringKeys option later if someone wants quoted strings everywhere.

Context: we are using YAML to obtain a readable representation of API data objects for debugging, and having consistent quoting everywhere helps.

Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification