### PR TITLE
encodeMap() error handling and TestEncoder_UnmarshallableTypes()

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -492,7 +492,7 @@ func (e *Encoder) encodeValue(ctx context.Context, v reflect.Value, column int) 
 		if value := e.encodePtrAnchor(v, column); value != nil {
 			return value, nil
 		}
-		return e.encodeMap(ctx, v, column), nil
+		return e.encodeMap(ctx, v, column)
 	default:
 		return nil, fmt.Errorf("unknown value type %s", v.Type().String())
 	}
@@ -684,7 +684,7 @@ func (e *Encoder) isTagAndMapNode(node ast.Node) bool {
 	return ok && e.isMapNode(tn.Value)
 }
 
-func (e *Encoder) encodeMap(ctx context.Context, value reflect.Value, column int) ast.Node {
+func (e *Encoder) encodeMap(ctx context.Context, value reflect.Value, column int) (ast.Node, error) {
 	node := ast.Mapping(token.New("", "", e.pos(column)), e.isFlowStyle)
 	keys := make([]interface{}, len(value.MapKeys()))
 	for i, k := range value.MapKeys() {
@@ -698,7 +698,7 @@ func (e *Encoder) encodeMap(ctx context.Context, value reflect.Value, column int
 		v := value.MapIndex(k)
 		value, err := e.encodeValue(ctx, v, column)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		if e.isMapNode(value) {
 			value.AddColumn(e.indentNum)
@@ -724,7 +724,7 @@ func (e *Encoder) encodeMap(ctx context.Context, value reflect.Value, column int
 		))
 		e.setSmartAnchor(vRef, keyText)
 	}
-	return node
+	return node, nil
 }
 
 // IsZeroer is used to check whether an object is zero to determine


### PR DESCRIPTION
## Problem

I encountered an issue where unmarshallable types in maps do not properly handle errors.

`bytes, err := yaml.Marshal(map[string]any{"a": make(chan int)})` returns a nil error and `string(bytes)` is `<nil>\n`.

Similarly, calling Marshal on nested `map[string]any{"a": map[string]any{"b": make(chan string)}}` returns a nil error and `string(bytes)` is `%!v(PANIC=String method: runtime error: invalid memory address or nil pointer dereference)\n`

## Solution

Add error to return value in `func (e *Encoder) encodeMap(ctx context.Context, value reflect.Value, column int) (ast.Node, error)` and return the error when value can't be encoded.

## Testing

Add new `func TestEncoder_UnmarshallableTypes(t *testing.T)` with these test cases:

* channel
* function
* complex number
* unsafe pointer
* uintptr
* map with channel
* nested map with func
* slice with channel
* nested slice with complex number
* struct with unsafe pointer