### PR TITLE
Fix validation error positioning for maps and structs

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1453,6 +1453,9 @@ func (d *Decoder) decodeStruct(ctx context.Context, dst reflect.Value, src ast.N
 					node, exists := keyToNodeMap[structField.RenderName]
 					if exists {
 						// TODO: to make FieldError message cutomizable
+						if node.Type() == ast.MappingType {
+							return errors.ErrSyntax(fmt.Sprintf("%s", err), node.GetToken().Prev.Prev)
+						}
 						return errors.ErrSyntax(fmt.Sprintf("%s", err), node.GetToken())
 					} else if t := src.GetToken(); t != nil && t.Prev != nil && t.Prev.Prev != nil {
 						// A missing required field will not be in the keyToNodeMap

--- a/testdata/validate_test.go
+++ b/testdata/validate_test.go
@@ -174,6 +174,22 @@ lt10: 20
 				Inner `yaml:",inline"`
 			}{},
 		},
+		{
+			TestName: "Test map",
+			YAMLContent: `
+map:
+  hello: hello
+  hello2: hello`,
+			ExpectedErr: `[2:4] Key: 'Map' Error:Field validation for 'Map' failed on the 'eq' tag
+>  2 | map:
+          ^
+   3 |   hello: hello
+   4 |   hello2: hello`,
+			Instance: &struct {
+				// Make sure that this map is not set
+				Map map[string]string `yaml:"map" validate:"eq=0"`
+			}{},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
As in #684 

Running validator on a map or struct results in such error output: 
```
=== RUN   TestStructValidator/Test_map
    validate_test.go:205: unexpected error: [3:8] Key: 'Map' Error:Field validation for 'Map' failed on the 'eq' tag
           2 | map:
        >  3 |   hello: hello
                      ^
           4 |   hello2: hello
```

The error arrow positioning is unexpected as it's pointing to inner map value instead of pointing to the token defining the map. This can be confusing for the consumers of an error. 


Expected output would be: 
```
=== RUN   TestStructValidator/Test_Required_map
    validate_test.go:205: unexpected error: [1:4] Key: 'Map' Error:Field validation for 'Map' failed on the 'eq' tag
           > 2 | map:
                     ^
           3 |   hello: hello
           4 |   hello2: hello
```

Fixes: #684
