### PR TITLE
feat: add global `OmitEmpty` encoding option

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -38,6 +38,7 @@ type Encoder struct {
 	anchorNameMap              map[string]struct{}
 	anchorCallback             func(*ast.AnchorNode, interface{}) error
 	customMarshalerMap         map[reflect.Type]func(interface{}) ([]byte, error)
+	omitEmpty                  bool
 	autoInt                    bool
 	useLiteralStyleIfMultiline bool
 	commentMap                 map[*Path][]*Comment
@@ -824,7 +825,7 @@ func (e *Encoder) encodeStruct(ctx context.Context, value reflect.Value, column 
 		}
 		fieldValue := value.FieldByName(field.Name)
 		structField := structFieldMap[field.Name]
-		if structField.IsOmitEmpty && e.isZeroValue(fieldValue) {
+		if (e.omitEmpty || structField.IsOmitEmpty) && e.isZeroValue(fieldValue) {
 			// omit encoding
 			continue
 		}

--- a/encode_test.go
+++ b/encode_test.go
@@ -465,7 +465,7 @@ func TestEncoder(t *testing.T) {
 			nil,
 		},
 
-		// Conditional flag
+		// Omitempty flag.
 		{
 			"a: 1\n",
 			struct {
@@ -482,7 +482,6 @@ func TestEncoder(t *testing.T) {
 			}{0, 0},
 			nil,
 		},
-
 		{
 			"a:\n  \"y\": \"\"\n",
 			struct {
@@ -496,7 +495,6 @@ func TestEncoder(t *testing.T) {
 			}{}},
 			nil,
 		},
-
 		{
 			"a: {}\n",
 			struct {
@@ -510,7 +508,6 @@ func TestEncoder(t *testing.T) {
 			}{}},
 			nil,
 		},
-
 		{
 			"a: {x: 1}\n",
 			struct {
@@ -518,7 +515,6 @@ func TestEncoder(t *testing.T) {
 			}{&struct{ X, y int }{1, 2}},
 			nil,
 		},
-
 		{
 			"{}\n",
 			struct {
@@ -526,7 +522,6 @@ func TestEncoder(t *testing.T) {
 			}{nil},
 			nil,
 		},
-
 		{
 			"a: {x: 0}\n",
 			struct {
@@ -534,7 +529,6 @@ func TestEncoder(t *testing.T) {
 			}{&struct{ X, y int }{}},
 			nil,
 		},
-
 		{
 			"a: {x: 1}\n",
 			struct {
@@ -567,8 +561,29 @@ func TestEncoder(t *testing.T) {
 			},
 			nil,
 		},
+		// OmitEmpty global option.
+		{
+			"a: 1\n",
+			struct {
+				A int
+				B int `yaml:"b,omitempty"`
+			}{1, 0},
+			[]yaml.EncodeOption{
+				yaml.OmitEmpty(),
+			},
+		},
+		{
+			"{}\n",
+			struct {
+				A int
+				B int `yaml:"b,omitempty"`
+			}{0, 0},
+			[]yaml.EncodeOption{
+				yaml.OmitEmpty(),
+			},
+		},
 
-		// Flow flag
+		// Flow flag.
 		{
 			"a: [1, 2]\n",
 			struct {

--- a/option.go
+++ b/option.go
@@ -215,6 +215,15 @@ func AutoInt() EncodeOption {
 	}
 }
 
+// OmitEmpty forces the encoder to assume an `omitempty` struct tag is
+// set on all the fields. See `Marshal` commentary for the `omitempty` tag logic.
+func OmitEmpty() EncodeOption {
+	return func(e *Encoder) error {
+		e.omitEmpty = true
+		return nil
+	}
+}
+
 // CommentPosition type of the position for comment.
 type CommentPosition int
 


### PR DESCRIPTION
Thanks for an amazing project! Go ecosystem struggle (e.g. https://github.com/GoogleCloudPlatform/prometheus-engine/issues/1629) with 3P types that lack a good marshalling practices. Many projects have config structs only designed for parsing. See https://github.com/goccy/go-yaml/issues/306 for the detailed motivation.

Fixes: https://github.com/goccy/go-yaml/issues/306

The feature mechanism is simple -- we ignore struct tag setting for omitempty. We assume it's always 'omitempty' if yaml.OmitEmpty() setting is set.

I confirm:

- [X] Describe the purpose for which you created this PR.  
- [X] Create test code that corresponds to the modification