### PR TITLE
chore: clarify omitempty behaviour.

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/netip"
 	"reflect"
 	"strconv"
 	"strings"
@@ -561,6 +562,18 @@ func TestEncoder(t *testing.T) {
 			},
 			nil,
 		},
+		// Highlighting differences of go-yaml omitempty vs std encoding/json
+		// omitempty. Encoding/json will emit the following fields: https://go.dev/play/p/VvNpdM0GD4d
+		{
+			"{}\n",
+			struct {
+				// This type has a custom IsZero method.
+				A netip.Addr         `yaml:"a,omitempty"`
+				B struct{ X, y int } `yaml:"b,omitempty"`
+			}{},
+			nil,
+		},
+
 		// OmitEmpty global option.
 		{
 			"a: 1\n",

--- a/yaml.go
+++ b/yaml.go
@@ -108,6 +108,9 @@ func (s MapSlice) ToMap() map[interface{}]interface{} {
 //	             fields are zero, unless they implement an IsZero
 //	             method (see the IsZeroer interface type), in which
 //	             case the field will be included if that method returns true.
+//	             Note that this definition is slightly different from the Go's
+//	             encoding/json 'omitempty' definition. It combines some elements
+//	             of 'omitempty' and 'omitzero'. See https://github.com/goccy/go-yaml/issues/695.
 //
 //	flow         Marshal using a flow style (useful for structs,
 //	             sequences and maps).


### PR DESCRIPTION
Fixes 0 step from https://github.com/goccy/go-yaml/issues/695.

