### PR TITLE
Treat output from TextMarshaler as string

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -22,6 +22,16 @@ import (
 var zero = 0
 var emptyStr = ""
 
+type TestTextMarshaler string
+
+func (t TestTextMarshaler) MarshalText() ([]byte, error) {
+	return []byte(t), nil
+}
+
+type TestTextUnmarshalerContainer struct {
+	V TestTextMarshaler
+}
+
 func TestEncoder(t *testing.T) {
 	tests := []struct {
 		source  string
@@ -729,6 +739,31 @@ func TestEncoder(t *testing.T) {
 		{
 			"v: 30s\n",
 			map[string]time.Duration{"v": 30 * time.Second},
+			nil,
+		},
+		{
+			"v: 30s\n",
+			map[string]*time.Duration{"v": ptr(30 * time.Second)},
+			nil,
+		},
+		{
+			"v: null\n",
+			map[string]*time.Duration{"v": nil},
+			nil,
+		},
+		{
+			"v: test\n",
+			TestTextUnmarshalerContainer{V: "test"},
+			nil,
+		},
+		{
+			"v: \"1\"\n",
+			TestTextUnmarshalerContainer{V: "1"},
+			nil,
+		},
+		{
+			"v: \"#\"\n",
+			TestTextUnmarshalerContainer{V: "#"},
 			nil,
 		},
 		// Quote style
@@ -1655,7 +1690,7 @@ func ExampleMarshal() {
 	// a: Hello speed demon
 	// b: 100
 	//
-	// field: 13
+	// field: "13"
 }
 
 func TestIssue356(t *testing.T) {
@@ -1938,4 +1973,8 @@ a: &anc !mytag
 			}
 		})
 	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }


### PR DESCRIPTION
Closes https://github.com/goccy/go-yaml/issues/689.

The original issue was that since `null.StringFrom` implements the `TextMarshaler` interface, `goccy/go-yaml` tries to interpret its output as a YAML document using `e.encodeDocument`. However, because the output contains a special character (in this case, `#`), the parser fails to handle it correctly and returns `nil`.

IIUC, the output from a `TextMarshaler` implementation should not be interpreted as a YAML document. It should be treated as a plain string, since `TextMarshaler` is intended to return a textual representation of a value. This behavior is consistent with `gopkg.in/yaml.v3`.

One side effect I noticed after making this change is related to how `*time.Time` is encoded. Previously, since `*time.Time` also implements `TextMarshaler`, it was being encoded by the code block below. After treating the output from `MarshalText()` as a string, the library started wrapping `*time.Time` values in double quotes. To prevent this, I updated the `encodeByMarshaler` function to handle `*time.Time` explicitly.

```
if marshaler, ok := iface.(encoding.TextMarshaler); ok {
		doc, err := marshaler.MarshalText()
		if err != nil {
			return nil, err
		}
		node, err := e.encodeDocument(doc)
...
}
```



- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification