### PR TITLE
Update golangci-lint to v2.1.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,49 +1,65 @@
-run:
-  timeout: 5m
-
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-  gci:
-    sections:
-      - "standard"
-      - "default"
-      - "prefix(github.com/goccy/go-yaml)"
-      - "blank"
-      - "dot"
-  gofmt:
-    simplify: true
-  govet:
-    disable:
-      - tests
-  misspell:
-    locale: US
-  perfsprint:
-    int-conversion: false
-    err-error: false
-    errorf: true
-    sprintf1: false
-    strconcat: false
-  staticcheck:
-    checks: ["all", "-ST1000", "-ST1005"]
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - gci
-    - gofmt
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - perfsprint
     - staticcheck
-    - typecheck
     - unused
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - staticcheck
+  settings:
+    errcheck:
+      without_tests: true
+    govet:
+      disable:
+        - tests
+    misspell:
+      locale: US
+    perfsprint:
+      int-conversion: false
+      err-error: false
+      errorf: true
+      sprintf1: false
+      strconcat: false
+    staticcheck:
+      checks:
+        - -ST1000
+        - -ST1005
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/goccy/go-yaml)
+        - blank
+        - dot
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ fmt: golangci-lint ## Ensure consistent code style
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-GOLANGCI_VERSION := 1.61.0
+GOLANGCI_VERSION := 2.1.2
 
 .PHONY: golangci-lint
 .PHONY: $(GOLANGCI_LINT)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	@test -s $(LOCALBIN)/golangci-lint && $(LOCALBIN)/golangci-lint version --format short | grep -q $(GOLANGCI_VERSION) || \
+	@test -s $(LOCALBIN)/golangci-lint && $(LOCALBIN)/golangci-lint version --short | grep -q $(GOLANGCI_VERSION) || \
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) v$(GOLANGCI_VERSION)

--- a/decode.go
+++ b/decode.go
@@ -295,7 +295,7 @@ func (d *Decoder) addSequenceNodeCommentToMap(node *ast.SequenceNode) {
 func (d *Decoder) addFootCommentToMap(node ast.Node) {
 	var (
 		footComment     *ast.CommentGroupNode
-		footCommentPath string = node.GetPath()
+		footCommentPath = node.GetPath()
 	)
 	switch n := node.(type) {
 	case *ast.SequenceNode:

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -251,10 +251,7 @@ func (p *Printer) isNewLineLastChar(s string) bool {
 }
 
 func (p *Printer) printBeforeTokens(tk *token.Token, minLine, extLine int) token.Tokens {
-	for {
-		if tk.Prev == nil {
-			break
-		}
+	for tk.Prev != nil {
 		if tk.Prev.Position.Line < minLine {
 			break
 		}


### PR DESCRIPTION
A small housekeeping to update the golangci-lint to the latest (from 1.61.0 to 2.1.2)

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification