### PR TITLE
feat: implement UnmarshalerError #704

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -894,7 +894,7 @@ func (d *Decoder) decodeValue(ctx context.Context, dst reflect.Value, src ast.No
 	}
 	if d.canDecodeByUnmarshaler(dst) {
 		if err := d.decodeByUnmarshaler(ctx, dst, src); err != nil {
-			return err
+			return errors.ErrUnmarshal(err, dst.Type(), src.GetToken())
 		}
 		return nil
 	}
@@ -1689,7 +1689,7 @@ func (d *Decoder) decodeMap(ctx context.Context, dst reflect.Value, src ast.Node
 		k := d.createDecodableValue(keyType)
 		if d.canDecodeByUnmarshaler(k) {
 			if err := d.decodeByUnmarshaler(ctx, k, key); err != nil {
-				return err
+				return errors.ErrUnmarshal(err, dst.Type(), src.GetToken())
 			}
 		} else {
 			keyVal, err := d.nodeToValue(ctx, key)

--- a/error.go
+++ b/error.go
@@ -26,6 +26,7 @@ type (
 	DuplicateKeyError       = errors.DuplicateKeyError
 	UnknownFieldError       = errors.UnknownFieldError
 	UnexpectedNodeTypeError = errors.UnexpectedNodeTypeError
+	UnmarshalerError        = errors.UnmarshalerError
 	Error                   = errors.Error
 )
 


### PR DESCRIPTION
Adds a new error type, `UnmarshalerError` which is used to wrap any errors returned from `decodeByUnmarshaler`