### PR TITLE
Optimize Marshal performance

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -237,7 +237,7 @@ func (d *Decoder) addHeadOrLineCommentToMap(node ast.Node) {
 	if commentGroup == nil {
 		return
 	}
-	texts := []string{}
+	texts := make([]string, 0, len(commentGroup.Comments))
 	targetLine := node.GetToken().Position.Line
 	minCommentLine := math.MaxInt
 	for _, comment := range commentGroup.Comments {
@@ -317,7 +317,7 @@ func (d *Decoder) addFootCommentToMap(node ast.Node) {
 	if footComment == nil {
 		return
 	}
-	var texts []string
+	texts := make([]string, 0, len(footComment.Comments))
 	for _, comment := range footComment.Comments {
 		texts = append(texts, comment.Token.Value)
 	}

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -102,7 +102,7 @@ func (p *Printer) PrintTokens(tokens token.Tokens) string {
 			p.LineNumberFormat = defaultLineNumberFormat
 		}
 	}
-	texts := []string{}
+	texts := make([]string, 0, len(tokens))
 	lineNumber := tokens[0].Position.Line
 	for _, tk := range tokens {
 		lines := strings.Split(tk.Origin, "\n")


### PR DESCRIPTION
Speeding up Marshal functions by saving memory allocations:

- prealloc when we know the cap of the slice
- using strings.Builder instead of fmt.Sprintf to build complex strings

Benchmarks:
![image](https://github.com/user-attachments/assets/56e01f15-bd19-4391-8853-5acbb4bcad06)

![image](https://github.com/user-attachments/assets/4897b7b3-c006-4d4e-86e5-e1483c2f32be)

Benchmark code:
```golang
func BenchmarkMarshal(b *testing.B) {
        type T struct {
                ID       int    `yaml:"id"`
                Message  string `yaml:"message"`
                Verified bool   `yaml:"verified,omitempty"`
        }
        t := T{
                ID:      100,
                Message: "Hello",
        }
        for i := 0; i < b.N; i++ {
                _, err := yaml.Marshal(&t)
                if err != nil {
                        b.Fatal(err)
                }
        }
}

func BenchmarkMarshalMap(b *testing.B) {
        type T struct {
                ID       int    `yaml:"id"`
                Message  string `yaml:"message"`
                Verified bool   `yaml:"verified,omitempty"`
        }
        t := T{
                ID:      100,
                Message: "Hello",
        }
        m := map[string]T{
                "a": t,
                "b": t,
                "c": t,
        }
        for i := 0; i < b.N; i++ {
                _, err := yaml.Marshal(m)
                if err != nil {
                        b.Fatal(err)
                }
        }
}
```
