### PR TITLE
Support implicit null

### DIFF
--- a/parser/context.go
+++ b/parser/context.go
@@ -120,7 +120,7 @@ func (c *context) next() bool {
 }
 
 func (c *context) insertNullToken(tk *Token) *Token {
-	nullToken := c.createNullToken(tk)
+	nullToken := c.createImplicitNullToken(tk)
 	c.insertToken(nullToken)
 	c.goNext()
 
@@ -128,7 +128,7 @@ func (c *context) insertNullToken(tk *Token) *Token {
 }
 
 func (c *context) addNullValueToken(tk *Token) *Token {
-	nullToken := c.createNullToken(tk)
+	nullToken := c.createImplicitNullToken(tk)
 	rawTk := nullToken.RawToken()
 
 	// add space for map or sequence value.
@@ -140,10 +140,12 @@ func (c *context) addNullValueToken(tk *Token) *Token {
 	return nullToken
 }
 
-func (c *context) createNullToken(base *Token) *Token {
+func (c *context) createImplicitNullToken(base *Token) *Token {
 	pos := *(base.RawToken().Position)
 	pos.Column++
-	return &Token{Token: token.New("null", " null", &pos)}
+	tk := token.New("null", " null", &pos)
+	tk.Type = token.ImplicitNullType
+	return &Token{Token: tk}
 }
 
 func (c *context) insertToken(tk *Token) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -304,7 +304,7 @@ func (p *parser) parseScalarValue(ctx *context, tk *Token) (ast.ScalarNode, erro
 	switch tk.Type() {
 	case token.MergeKeyType:
 		return newMergeKeyNode(ctx, tk)
-	case token.NullType:
+	case token.NullType, token.ImplicitNullType:
 		return newNullNode(ctx, tk)
 	case token.BoolType:
 		return newBoolNode(ctx, tk)
@@ -747,7 +747,7 @@ func (p *parser) parseMapValue(ctx *context, key ast.MapKeyNode, colonTk *Token)
 		// next
 		group := &TokenGroup{
 			Type:   TokenGroupAnchor,
-			Tokens: []*Token{tk, ctx.createNullToken(tk)},
+			Tokens: []*Token{tk, ctx.createImplicitNullToken(tk)},
 		}
 		anchor, err := p.parseAnchor(ctx.withGroup(group), group)
 		if err != nil {
@@ -784,7 +784,7 @@ func (p *parser) parseMapValue(ctx *context, key ast.MapKeyNode, colonTk *Token)
 		// next
 		group := &TokenGroup{
 			Type:   TokenGroupAnchor,
-			Tokens: []*Token{tk, ctx.createNullToken(tk)},
+			Tokens: []*Token{tk, ctx.createImplicitNullToken(tk)},
 		}
 		anchor, err := p.parseAnchor(ctx.withGroup(group), group)
 		if err != nil {
@@ -976,7 +976,7 @@ func (p *parser) parseTag(ctx *context) (*ast.TagNode, error) {
 
 func (p *parser) parseTagValue(ctx *context, tagRawTk *token.Token, tk *Token) (ast.Node, error) {
 	if tk == nil {
-		return newNullNode(ctx, ctx.createNullToken(&Token{Token: tagRawTk}))
+		return newNullNode(ctx, ctx.createImplicitNullToken(&Token{Token: tagRawTk}))
 	}
 	switch token.ReservedTagKeyword(tagRawTk.Value) {
 	case token.MappingTag, token.SetTag:
@@ -1141,7 +1141,7 @@ func (p *parser) parseSequenceValue(ctx *context, seqTk *Token) (ast.Node, error
 		// -
 		group := &TokenGroup{
 			Type:   TokenGroupAnchor,
-			Tokens: []*Token{tk, ctx.createNullToken(tk)},
+			Tokens: []*Token{tk, ctx.createImplicitNullToken(tk)},
 		}
 		anchor, err := p.parseAnchor(ctx.withGroup(group), group)
 		if err != nil {
@@ -1178,7 +1178,7 @@ func (p *parser) parseSequenceValue(ctx *context, seqTk *Token) (ast.Node, error
 		// next
 		group := &TokenGroup{
 			Type:   TokenGroupAnchor,
-			Tokens: []*Token{tk, ctx.createNullToken(tk)},
+			Tokens: []*Token{tk, ctx.createImplicitNullToken(tk)},
 		}
 		anchor, err := p.parseAnchor(ctx.withGroup(group), group)
 		if err != nil {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -311,7 +311,7 @@ a: 0 - 1
 - a:
    b: c
    d: e
-- f: null
+- f:
   g: h
 `,
 		},
@@ -351,7 +351,7 @@ a:
 -     a     :
       b: c
 `, `
-- a: null
+- a:
   b: c
 `,
 		},
@@ -740,8 +740,8 @@ d: e
 `,
 			`
 a:
- b: &anchor null
- c: &anchor2 null
+ b: &anchor
+ c: &anchor2
 d: e
 `,
 		},
@@ -1567,7 +1567,7 @@ foo:
 `
 		expected := `
 foo:
-  bar: null # comment
+  bar: # comment
   baz: 1`
 		f, err := parser.ParseBytes([]byte(content), parser.ParseComments)
 		if err != nil {
@@ -1590,7 +1590,7 @@ foo:
 `
 		expected := `
 foo:
-  bar: null
+  bar:
   # comment
   baz: 1`
 		f, err := parser.ParseBytes([]byte(content), parser.ParseComments)
@@ -1620,7 +1620,7 @@ baz: 1`
 		}
 		expected := `
 foo:
-  bar: null
+  bar:
 # comment
 baz: 1`
 		got := f.Docs[0].String()

--- a/parser/token.go
+++ b/parser/token.go
@@ -709,6 +709,7 @@ func isScalarType(tk *Token) bool {
 		typ == token.LiteralType ||
 		typ == token.FoldedType ||
 		typ == token.NullType ||
+		typ == token.ImplicitNullType ||
 		typ == token.BoolType ||
 		typ == token.IntegerType ||
 		typ == token.BinaryIntegerType ||

--- a/token/token.go
+++ b/token/token.go
@@ -102,6 +102,10 @@ const (
 	SpaceType
 	// NullType type for Null token
 	NullType
+	// ImplicitNullType type for implicit Null token.
+	// This is used when explicit keywords such as null or ~ are not specified.
+	// It is distinguished during encoding and output as an empty string.
+	ImplicitNullType
 	// InfinityType type for Infinity token
 	InfinityType
 	// NanType type for Nan token
@@ -187,6 +191,8 @@ func (t Type) String() string {
 		return "Float"
 	case NullType:
 		return "Null"
+	case ImplicitNullType:
+		return "ImplicitNull"
 	case InfinityType:
 		return "Infinity"
 	case NanType:


### PR DESCRIPTION
resolve https://github.com/goccy/go-yaml/issues/710

Add `ImplicitNullType` as a token type.
`ImplicitNullType` is used during the parser phase when inserting a null token. If ast.NullNode holds this token, the "null" string will be omitted when converted to a string. This enables reversible conversion of implicit nulls.