### PR TITLE
tests: add (failing) FuzzEncodeFromJSON

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,6 +1,8 @@
 package yaml_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -53,4 +55,66 @@ verified: true
 			t.Log(err.Error())
 		}
 	})
+}
+
+// FuzzEncodeFromJSON checks that any JSON encoded value can also be encoded as YAML... and decoded.
+func FuzzEncodeFromJSON(f *testing.F) {
+	f.Add(`null`)
+	f.Add(`""`)
+	f.Add(`0`)
+	f.Add(`true`)
+	f.Add(`false`)
+	f.Add(`{}`)
+	f.Add(`[]`)
+	f.Add(`[[]]`)
+	f.Add(`{"a":[]}`)
+
+	f.Fuzz(func(t *testing.T, s string) {
+
+		var v interface{}
+		if err := json.Unmarshal([]byte(s), &v); err != nil {
+			t.Skip("not valid JSON")
+		}
+
+		t.Logf("JSON %q", s)
+		t.Logf("Go   %T %#[1]v <%[1]x>", v)
+
+		// Encode as YAML
+		b, err := yaml.Marshal(v)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("YAML %q <%[1]x>", b)
+
+		// Decode as YAML
+		var v2 interface{}
+		if err := yaml.Unmarshal(b, &v2); err != nil {
+			t.Error(err)
+		}
+
+		t.Logf("Go   %T %#[1]v <%[1]x>", v2)
+
+		/*
+			// Handling of number is different, so we can't have universal exact matching
+			if !reflect.DeepEqual(v2, v) {
+				t.Errorf("mismatch:\n-      got: %#v\n- expected: %#v", v2, v)
+			}
+		*/
+
+		b2, err := yaml.Marshal(v2)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("YAML %q <%[1]x>", b2)
+
+		if !bytes.Equal(b, b2) {
+			t.Errorf("Marshal->Unmarshal->Marshal mismatch:\n- expected: %q\n- got:      %q", b, b2)
+		}
+
+	})
+}
+
+func TestEncodeString(t *testing.T) {
+	b, _ := yaml.Marshal(`\n`)
+	t.Logf("%q <%[1]x>", string(b))
 }


### PR DESCRIPTION
Add `FuzzEncodeFromJSON` which enforces that JSON content is correctly parsed (YAML is a superset of JSON) and rountrips.

This increase code coverage.

The test reveals bugs (applied against c430438700dc5bcac447fc0a6a88e6e756ba7f52):
```console
$ go test -fuzz FuzzEnco
fuzz: elapsed: 0s, gathering baseline coverage: 0/258 completed
fuzz: elapsed: 0s, gathering baseline coverage: 258/258 completed, now fuzzing with 8 workers
fuzz: elapsed: 1s, execs: 1753 (1513/sec), new interesting: 5 (total: 263)
--- FAIL: FuzzEncodeFromJSON (1.18s)
    --- FAIL: FuzzEncodeFromJSON (0.00s)
        fuzz_test.go:79: JSON "\"---\""
        fuzz_test.go:80: Go   string "---" <2d2d2d>
        fuzz_test.go:87: YAML "---\n" <2d2d2d0a>
        fuzz_test.go:95: Go   <nil> <nil> <%!x(<nil>)>
        fuzz_test.go:108: YAML "null\n" <6e756c6c0a>
        fuzz_test.go:111: Marshal->Unmarshal->Marshal mismatch:
            - expected: "---\n"
            - got:      "null\n"
    
    Failing input written to testdata/fuzz/FuzzEncodeFromJSON/40b11a986d02285b
    To re-run:
    go test -run=FuzzEncodeFromJSON/40b11a986d02285b
FAIL
exit status 1
FAIL	github.com/goccy/go-yaml	1.571s
```


Note: I had initially written that code for `gopkg.in/yaml.v3` (see go-yaml/yaml#1028) then [`sigs.k8s.io/yaml/yaml.v3`](https://pkg.go.dev/sigs.k8s.io/yaml/yaml.v3) (see kubernetes-sigs/yaml#110) where it revealed bugs that nobody handled.

