### PR TITLE
Prevent panic when decoding string named types

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -25,6 +25,8 @@ type Child struct {
 	C int `yaml:"-"`
 }
 
+type TestString string
+
 func TestDecoder(t *testing.T) {
 	tests := []struct {
 		source string
@@ -34,6 +36,10 @@ func TestDecoder(t *testing.T) {
 		{
 			source: "v: hi\n",
 			value:  map[string]string{"v": "hi"},
+		},
+		{
+			source: "v: hi\n",
+			value:  map[string]TestString{"v": "hi"},
 		},
 		{
 			source: "v: \"true\"\n",
@@ -54,6 +60,10 @@ func TestDecoder(t *testing.T) {
 		{
 			source: "v: 10\n",
 			value:  map[string]string{"v": "10"},
+		},
+		{
+			source: "v: 10\n",
+			value:  map[string]TestString{"v": "10"},
 		},
 		{
 			source: "v: -10\n",


### PR DESCRIPTION
Closes https://github.com/goccy/go-yaml/issues/741

Previously, decoding string named type fields returned the converted string values directly, which could lead to a panic if the types didn’t match. This update adds a type check and performs the conversion if the types do not match.


Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification