### PR TITLE
Add PreserveCommentIndents to provide ability to preserve comments with odd indentation

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -149,7 +149,7 @@ func (e *Encoder) setCommentByCommentMap(node ast.Node) error {
 			for _, text := range comment.Texts {
 				commentTokens = append(commentTokens, token.New(text, text, nil))
 			}
-			commentGroup := ast.CommentGroup(commentTokens)
+			commentGroup := ast.CommentGroup(commentTokens, false)
 			switch comment.Position {
 			case CommentHeadPosition:
 				if err := e.setHeadComment(node, n, commentGroup); err != nil {

--- a/parser/node.go
+++ b/parser/node.go
@@ -230,7 +230,7 @@ func setLineComment(ctx *context, node ast.Node, tk *Token) error {
 	if tk == nil || tk.LineComment == nil {
 		return nil
 	}
-	comment := ast.CommentGroup([]*token.Token{tk.LineComment})
+	comment := ast.CommentGroup([]*token.Token{tk.LineComment}, false)
 	comment.SetPath(ctx.path)
 	if err := node.SetComment(comment); err != nil {
 		return err

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1842,7 +1842,7 @@ topLevelNode:
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			f, err := parser.ParseBytes([]byte(test.yaml), parser.ParseComments)
+			f, err := parser.ParseBytes([]byte(test.yaml), parser.ParseComments|parser.PreserveCommentIndents)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}


### PR DESCRIPTION
This PR solves: https://github.com/goccy/go-yaml/issues/747 (and is a follow up to https://github.com/goccy/go-yaml/pull/734)

It allows for the parser (and AST nodes) to pre configured to preserve the level of indentation that comments are found to be at. This helps to cover some additional use-cases that cannot be supported currently like the one I reported initially here: https://github.com/goccy/go-yaml/issues/713#issuecomment-2876659824

This is accomplished by adding a new mode that is used along side with ParseComments mode. Notably if the new mode is used alone it currently will not work.

I opted for a new mode because based on the report from https://github.com/goccy/go-yaml/issues/713 and fix in https://github.com/goccy/go-yaml/pull/734 it seems some users/use-cases desire comments Parsed but not preserved at same indent. It seems this functions as a minimal beautification step in that case.

---

### Future Consideration

This does not cover, nor seek to attempt covering, other comment related indent concerns. For instance in-line comments may have odd spacing following the value that the comment is after. So something like:

```
		{
			name: "commented values.yaml with odd in-line indentation",
			yaml: `
topLevelNode:
  attribute: true          # comment about the current line's attribute
`,
		},
```

While it could be possible to preserve this spacing in some cases - i.e. to ensure the `#` outputs in the same column as it is found. This would be a risk as, in cases where the value length changes (grows) a collision could occur. So because that solution is quite a different issue than indent levels this has been intentionally excluded from this fix.

---

Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification