### PR TITLE
fix(encoder): handle write errors in EncodeContext

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -99,10 +99,14 @@ func (e *Encoder) EncodeContext(ctx context.Context, v interface{}) error {
 		e.written = true
 	} else {
 		// write document separator
-		_, _ = e.writer.Write([]byte("---\n"))
+		if _, err := e.writer.Write([]byte("---\n")); err != nil {
+			return err
+		}
 	}
 	var p printer.Printer
-	_, _ = e.writer.Write(p.PrintNode(node))
+	if _, err := e.writer.Write(p.PrintNode(node)); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Adds error handling for Write operations in the Encoder.EncodeContext method. Previously it ignored any errors that might occur when writing to the underlying writer. Also add test cases to verify the error handling behavior in different scenarios (first document write, separator write, subsequent document write).

This change ensures the encoder reliably reports IO errors ratherthan silently failing when the destination writer cannot accept data.

Before submitting your PR, please confirm the following.

- [ ] Describe the purpose for which you created this PR.  
- [ ] Create test code that corresponds to the modification