### PR TITLE
Revert "feat: Dont make copies of structs for validation"

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1451,7 +1451,7 @@ func (d *Decoder) decodeStruct(ctx context.Context, dst reflect.Value, src ast.N
 	}
 
 	if d.validator != nil {
-		if err := d.validator.Struct(dst.Addr().Interface()); err != nil {
+		if err := d.validator.Struct(dst.Interface()); err != nil {
 			ev := reflect.ValueOf(err)
 			if ev.Type().Kind() == reflect.Slice {
 				for i := 0; i < ev.Len(); i++ {


### PR DESCRIPTION
Reverts goccy/go-yaml#737
This change breaks backward compatibility by modifying the struct to pointer internally, so we should revert it 🙇