### PR TITLE
fix(parser): correctly handle empty documents in multi-document yaml

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -725,6 +725,20 @@ a:
 d: e
 `,
 		},
+		{
+			`
+a: b
+---
+---
+c: d
+`,
+			`
+a: b
+---
+---
+c: d
+`,
+		},
 	}
 
 	for _, test := range tests {
@@ -1789,6 +1803,9 @@ func (c *pathCapturer) Visit(node ast.Node) ast.Visitor {
 type Visitor struct{}
 
 func (v *Visitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return nil
+	}
 	tk := node.GetToken()
 	tk.Prev = nil
 	tk.Next = nil


### PR DESCRIPTION
It fixes a bug where parsing a multi-document yaml file with an empty document (`---` with no content) would cause the parser to stop processing subsequent documents. The document token grouping logic in parser is updated to ensure every document boundary (---), even if empty, results in a document token. Parsing continues after empty documents.

fixes #765

As I am not fully familiar with the codebase, I am not certain this is the best or most complete fix and welcome feedback or suggestions for additional test coverage.

Before submitting your PR, please confirm the following.

- [x] Describe the purpose for which you created this PR.  
- [x] Create test code that corresponds to the modification