### PR TITLE
fix(decoder): Correctly unmarshal !!int tagged values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -81,6 +81,36 @@ func (d *Decoder) isExceededMaxDepth() bool {
 	return d.decodeDepth > maxDecodeDepth
 }
 
+func (d *Decoder) castToInt(v interface{}) interface{} {
+	switch vv := v.(type) {
+	case int:
+		return int64(vv)
+	case int8:
+		return int64(vv)
+	case int16:
+		return int64(vv)
+	case int32:
+		return int64(vv)
+	case int64:
+		return vv
+	case uint:
+		return uint64(vv)
+	case uint8:
+		return uint64(vv)
+	case uint16:
+		return uint64(vv)
+	case uint32:
+		return uint64(vv)
+	case uint64:
+		return vv
+	case string:
+		// if error occurred, return zero value
+		i, _ := strconv.ParseInt(vv, 10, 64)
+		return i
+	}
+	return 0
+}
+
 func (d *Decoder) castToFloat(v interface{}) interface{} {
 	switch vv := v.(type) {
 	case int:
@@ -382,8 +412,7 @@ func (d *Decoder) nodeToValue(ctx context.Context, node ast.Node) (any, error) {
 			if err != nil {
 				return nil, err
 			}
-			i, _ := strconv.Atoi(fmt.Sprint(v))
-			return i, nil
+			return d.castToInt(v), nil
 		case token.FloatTag:
 			v, err := d.nodeToValue(ctx, n.Value)
 			if err != nil {

--- a/decode_test.go
+++ b/decode_test.go
@@ -587,16 +587,40 @@ func TestDecoder(t *testing.T) {
 
 		// Explicit tags.
 		{
+			source: "v: !!int 'not-an-int'",
+			value:  map[string]int{"v": 0},
+		},
+		{
+			source: "v: !!int '000'",
+			value:  map[string]int{"v": 0},
+		},
+		{
+			source: "v: !!int '007'",
+			value:  map[string]int{"v": 7},
+		},
+		{
+			source: "v: !!int '-007'",
+			value:  map[string]int{"v": -7},
+		},
+		{
+			source: "v: !!int 0xff",
+			value:  map[string]int{"v": 255},
+		},
+		{
+			source: "v: !!int 0o10",
+			value:  map[string]int{"v": 8},
+		},
+		{
 			source: "v: !!float '1.1'",
-			value:  map[string]interface{}{"v": 1.1},
+			value:  map[string]float64{"v": 1.1},
 		},
 		{
 			source: "v: !!float 0",
-			value:  map[string]interface{}{"v": float64(0)},
+			value:  map[string]float64{"v": 0},
 		},
 		{
 			source: "v: !!float -1",
-			value:  map[string]interface{}{"v": float64(-1)},
+			value:  map[string]float64{"v": -1},
 		},
 		{
 			source: "v: !!null ''",


### PR DESCRIPTION
This PR fixes the unmarshaling logic to properly handle YAML values with explicit `!!int` tags. For example:

```go
var data map[string]int
err := yaml.Unmarshal([]byte("a: !!int 42"), &data)
```

Error returned:

```
Failed to process YAML: [1:4] cannot unmarshal int into Go value of type int
        >  1 | a: !!int 42
                  ^
```