### PR TITLE
Fix #776

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1117,14 +1117,14 @@ func (d *Decoder) createDecodedNewValue(
 	return d.castToAssignableValue(newValue, typ, node)
 }
 
-func (d *Decoder) keyToNodeMap(ctx context.Context, node ast.Node, ignoreMergeKey bool, getKeyOrValueNode func(*ast.MapNodeIter) ast.Node) (map[string]ast.Node, error) {
+func (d *Decoder) _keyToNodeMap(ctx context.Context, node ast.Node, ignoreMergeKey bool, isMerge bool, getKeyOrValueNode func(*ast.MapNodeIter) ast.Node) (map[string]ast.Node, error) {
 	d.stepIn()
 	defer d.stepOut()
 	if d.isExceededMaxDepth() {
 		return nil, ErrExceededMaxDepth
 	}
 
-	mapNode, err := d.getMapNode(node, false)
+	mapNode, err := d.getMapNode(node, isMerge)
 	if err != nil {
 		return nil, err
 	}
@@ -1137,7 +1137,7 @@ func (d *Decoder) keyToNodeMap(ctx context.Context, node ast.Node, ignoreMergeKe
 			if ignoreMergeKey {
 				continue
 			}
-			mergeMap, err := d.keyToNodeMap(ctx, mapIter.Value(), ignoreMergeKey, getKeyOrValueNode)
+			mergeMap, err := d._keyToNodeMap(ctx, mapIter.Value(), ignoreMergeKey, true, getKeyOrValueNode)
 			if err != nil {
 				return nil, err
 			}
@@ -1163,6 +1163,10 @@ func (d *Decoder) keyToNodeMap(ctx context.Context, node ast.Node, ignoreMergeKe
 		}
 	}
 	return keyToNodeMap, nil
+}
+
+func (d *Decoder) keyToNodeMap(ctx context.Context, node ast.Node, ignoreMergeKey bool, getKeyOrValueNode func(*ast.MapNodeIter) ast.Node) (map[string]ast.Node, error) {
+	return d._keyToNodeMap(ctx, node, ignoreMergeKey, false, getKeyOrValueNode)
 }
 
 func (d *Decoder) keyToKeyNodeMap(ctx context.Context, node ast.Node, ignoreMergeKey bool) (map[string]ast.Node, error) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -657,6 +657,63 @@ merge:
 				"merge": {{Key: "foo", Value: 1}, {Key: "bar", Value: 2}},
 			},
 		},
+		// Issue #776
+		{
+			source: `
+a: &a
+  value: 100
+
+b: &b
+  unit: "m/s"
+
+c:
+  <<: [*a, *b]
+  d: var_x
+`,
+			value: struct {
+				C struct {
+					Value int    `yaml:"value"`
+					Unit  string `yaml:"unit"`
+					D     string `yaml:"d"`
+				} `yaml:"c"`
+			}{
+				C: struct {
+					Value int    `yaml:"value"`
+					Unit  string `yaml:"unit"`
+					D     string `yaml:"d"`
+				}{
+					Value: 100,
+					Unit:  "m/s",
+					D:     "var_x",
+				},
+			},
+		},
+		{
+			source: `
+a: &a
+  value: 100
+
+b: &b
+  unit: "m/s"
+
+c:
+  <<: [*a, *b]
+  d: var_x
+`,
+			value: map[string]any{
+				"c": map[string]any{
+					"value": 100,
+					"unit":  "m/s",
+					"d":     "var_x",
+				},
+				"a": map[string]any{
+					"value": 100,
+				},
+				"b": map[string]any{
+					"unit": "m/s",
+				},
+			},
+		},
 
 		// Flow sequence
 		{


### PR DESCRIPTION
Unmarshal from yamls with sequence merge key has been working fine for generic maps (aka. map[string]any types), but has been broken for structs: see #776 for more details. 

This commits fixes that, by properly handling marking a sequence as `isMerge` in keyToNodeMap. Previously it always assumed that the entry node will be always a map, despite having logic for properly handling these.

A test case was also added, one which exercises struct unmarshaling logic. 

Fixes: #776 