### PR TITLE
Ability for set initor

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -46,6 +46,7 @@ type Decoder struct {
 	parsedFile           *ast.File
 	streamIndex          int
 	decodeDepth          int
+	initer               Initer
 }
 
 // NewDecoder returns a new decoder that reads from r.
@@ -64,6 +65,7 @@ func NewDecoder(r io.Reader, opts ...DecodeOption) *Decoder {
 		disallowUnknownField: false,
 		allowDuplicateMapKey: false,
 		useOrderedMap:        false,
+		initer:               DefaultInitier,
 	}
 }
 
@@ -476,21 +478,44 @@ func (d *Decoder) nodeToValue(ctx context.Context, node ast.Node) (any, error) {
 			}
 			iter := value.MapRange()
 			if d.useOrderedMap {
-				m := MapSlice{}
+				t := reflect.TypeOf(MapSlice{})
+				m, err := d.initer(ctx, d, n, t, reflect.Zero(t))
+				if err != nil {
+					return nil, err
+				}
+
+				mc, ok := m.(MapSlice)
+				if !ok {
+					return nil, errors.ErrTypeMismatch(t, reflect.TypeOf(m), n.GetToken())
+				}
+
 				for iter.Next() {
-					if err := d.setToOrderedMapValue(ctx, iter.KeyValue(), &m); err != nil {
+					if err := d.setToOrderedMapValue(ctx, iter.KeyValue(), &mc); err != nil {
 						return nil, err
 					}
 				}
-				return m, nil
+
+				return mc, nil
 			}
-			m := make(map[string]any)
+
+			t := reflect.TypeOf(map[string]interface{}{})
+			m, err := d.initer(ctx, d, n, t, reflect.Zero(t))
+			if err != nil {
+				return nil, err
+			}
+
+			mc, ok := m.(map[string]interface{})
+			if !ok {
+				return nil, errors.ErrTypeMismatch(t, reflect.TypeOf(m), n.GetToken())
+			}
+
 			for iter.Next() {
-				if err := d.setToMapValue(ctx, iter.KeyValue(), m); err != nil {
+				if err := d.setToMapValue(ctx, iter.KeyValue(), mc); err != nil {
 					return nil, err
 				}
 			}
-			return m, nil
+
+			return mc, nil
 		}
 		key, err := d.mapKeyNodeToString(ctx, n.Key)
 		if err != nil {
@@ -501,40 +526,101 @@ func (d *Decoder) nodeToValue(ctx context.Context, node ast.Node) (any, error) {
 			if err != nil {
 				return nil, err
 			}
-			return MapSlice{{Key: key, Value: v}}, nil
+
+			t := reflect.TypeOf(MapSlice{})
+			m, err := d.initer(ctx, d, n, t, reflect.Zero(t))
+			if err != nil {
+				return nil, err
+			}
+
+			mc, ok := m.(MapSlice)
+			if !ok {
+				return nil, errors.ErrTypeMismatch(t, reflect.TypeOf(m), n.GetToken())
+			}
+
+			return append(mc, MapItem{Key: key, Value: v}), nil
 		}
+
 		v, err := d.nodeToValue(ctx, n.Value)
 		if err != nil {
 			return nil, err
 		}
-		return map[string]interface{}{key: v}, nil
+
+		t := reflect.TypeOf(map[string]interface{}{})
+		m, err := d.initer(ctx, d, n, t, reflect.Zero(t))
+		if err != nil {
+			return nil, err
+		}
+
+		mc, ok := m.(map[string]interface{})
+		if !ok {
+			return nil, errors.ErrTypeMismatch(t, reflect.TypeOf(m), n.GetToken())
+		}
+
+		mc[key] = v
+
+		return mc, nil
 	case *ast.MappingNode:
 		if d.useOrderedMap {
-			m := make(MapSlice, 0, len(n.Values))
+			t := reflect.TypeOf(MapSlice{})
+			m, err := d.initer(ctx, d, n, t, reflect.Zero(t))
+			if err != nil {
+				return nil, err
+			}
+
+			mc, ok := m.(MapSlice)
+			if !ok {
+				return nil, errors.ErrTypeMismatch(t, reflect.TypeOf(m), n.GetToken())
+			}
+
 			for _, value := range n.Values {
-				if err := d.setToOrderedMapValue(ctx, value, &m); err != nil {
+				if err := d.setToOrderedMapValue(ctx, value, &mc); err != nil {
 					return nil, err
 				}
 			}
-			return m, nil
+
+			return mc, nil
 		}
-		m := make(map[string]interface{}, len(n.Values))
+
+		t := reflect.TypeOf(map[string]interface{}{})
+		m, err := d.initer(ctx, d, n, t, reflect.Zero(t))
+		if err != nil {
+			return nil, err
+		}
+
+		mc, ok := m.(map[string]interface{})
+		if !ok {
+			return nil, errors.ErrTypeMismatch(t, reflect.TypeOf(m), n.GetToken())
+		}
+
 		for _, value := range n.Values {
-			if err := d.setToMapValue(ctx, value, m); err != nil {
+			if err := d.setToMapValue(ctx, value, mc); err != nil {
 				return nil, err
 			}
 		}
-		return m, nil
+
+		return mc, nil
 	case *ast.SequenceNode:
-		v := make([]interface{}, 0, len(n.Values))
+		t := reflect.TypeOf([]interface{}{})
+		v, err := d.initer(ctx, d, n, t, reflect.Zero(t))
+		if err != nil {
+			return nil, err
+		}
+
+		vc, ok := v.([]interface{})
+		if !ok {
+			return nil, errors.ErrTypeMismatch(t, reflect.TypeOf(v), n.GetToken())
+		}
+
 		for _, value := range n.Values {
 			vv, err := d.nodeToValue(ctx, value)
 			if err != nil {
 				return nil, err
 			}
-			v = append(v, vv)
+			vc = append(vc, vv)
 		}
-		return v, nil
+
+		return vc, nil
 	}
 	return nil, nil
 }
@@ -893,6 +979,22 @@ func (d *Decoder) decodeValue(ctx context.Context, dst reflect.Value, src ast.No
 	}
 	if !dst.IsValid() {
 		return nil
+	}
+
+	if !dst.IsZero() {
+		val, err := d.initer(ctx, d, src, dst.Type(), dst)
+		if err != nil {
+			return err
+		}
+
+		vOf := reflect.ValueOf(val)
+		if val != nil {
+			if vOf.Type() != dst.Type() {
+				return errors.ErrTypeMismatch(dst.Type(), vOf.Type(), src.GetToken())
+			}
+
+			dst.Set(vOf)
+		}
 	}
 
 	if src.Type() == ast.AnchorType {
@@ -1325,6 +1427,11 @@ func (d *Decoder) decodeStruct(ctx context.Context, dst reflect.Value, src ast.N
 		dst.Set(srcValue)
 		return nil
 	}
+	c, err := d.initer(ctx, d, src, structType, dst)
+	if err != nil {
+		return err
+	}
+	dst.Set(reflect.ValueOf(c))
 	structFieldMap, err := structFieldMap(structType)
 	if err != nil {
 		return err
@@ -1574,9 +1681,19 @@ func (d *Decoder) decodeSlice(ctx context.Context, dst reflect.Value, src ast.No
 	if arrayNode == nil {
 		return nil
 	}
-	iter := arrayNode.ArrayRange()
+
 	sliceType := dst.Type()
-	sliceValue := reflect.MakeSlice(sliceType, 0, iter.Len())
+	v, err := d.initer(ctx, d, arrayNode, sliceType, dst)
+	if err != nil {
+		return err
+	}
+
+	sliceValue := reflect.ValueOf(v)
+	if sliceValue.Type() != sliceType {
+		return errors.ErrTypeMismatch(sliceType, sliceValue.Type(), src.GetToken())
+	}
+
+	iter := arrayNode.ArrayRange()
 	elemType := sliceType.Elem()
 
 	var foundErr error
@@ -1711,7 +1828,17 @@ func (d *Decoder) decodeMap(ctx context.Context, dst reflect.Value, src ast.Node
 		return err
 	}
 	mapType := dst.Type()
-	mapValue := reflect.MakeMap(mapType)
+
+	v, err := d.initer(ctx, d, mapNode, mapType, dst)
+	if err != nil {
+		return err
+	}
+
+	mapValue := reflect.ValueOf(v)
+	if mapValue.Type() != mapType {
+		return errors.ErrTypeMismatch(mapType, mapValue.Type(), src.GetToken())
+	}
+
 	keyType := mapValue.Type().Key()
 	valueType := mapValue.Type().Elem()
 	mapIter := mapNode.MapRange()
@@ -2023,4 +2150,44 @@ func (d *Decoder) DecodeFromNodeContext(ctx context.Context, node ast.Node, v in
 		return err
 	}
 	return nil
+}
+
+func (d *Decoder) IsRecursiveDir() bool {
+	return d.isRecursiveDir
+}
+
+func (d *Decoder) IsResolvedReference() bool {
+	return d.isResolvedReference
+}
+
+func (d *Decoder) Validator() StructValidator {
+	return d.validator
+}
+
+func (d *Decoder) DisallowUnknownField() bool {
+	return d.disallowUnknownField
+}
+
+func (d *Decoder) AllowDuplicateMapKey() bool {
+	return d.allowDuplicateMapKey
+}
+
+func (d *Decoder) UseOrderedMap() bool {
+	return d.useOrderedMap
+}
+
+func (d *Decoder) UseJSONUnmarshaler() bool {
+	return d.useJSONUnmarshaler
+}
+
+func (d *Decoder) ParsedFileName() string {
+	return d.parsedFile.Name
+}
+
+func (d *Decoder) StreamIndex() int {
+	return d.streamIndex
+}
+
+func (d *Decoder) DecodeDepth() int {
+	return d.decodeDepth
 }

--- a/option.go
+++ b/option.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 
 	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/internal/errors"
+	"github.com/goccy/go-yaml/token"
 )
 
 // DecodeOption functional option type for Decoder
@@ -338,6 +340,75 @@ func CommentToMap(cm CommentMap) DecodeOption {
 			return ErrInvalidCommentMapValue
 		}
 		d.toCommentMap = cm
+		return nil
+	}
+}
+
+// Initializes a value before parsing. This is especially useful when using default values ​​for structures, initializing slices, or the like.
+type Initer = func(ctx context.Context, d *Decoder, node interface{}, t reflect.Type, dst reflect.Value) (interface{}, error)
+
+func DefaultInitier(ctx context.Context, d *Decoder, node interface{}, t reflect.Type, dst reflect.Value) (interface{}, error) {
+	switch t.Kind() {
+	case reflect.Slice:
+		var l int
+		switch n := node.(type) {
+		case *ast.SequenceNode:
+			l = len(n.Values)
+		case ast.ArrayNode:
+			iter := n.ArrayRange()
+			if iter != nil {
+				l = iter.Len()
+			}
+
+		}
+
+		return reflect.MakeSlice(t, 0, l).Interface(), nil
+	case reflect.Map:
+		if d.UseOrderedMap() {
+			var l int
+			if n, ok := node.(*ast.MappingNode); ok {
+				l = len(n.Values)
+			}
+
+			return make(MapSlice, 0, l), nil
+		}
+
+		return reflect.MakeMap(t).Interface(), nil
+	case reflect.Struct:
+		return dst.Interface(), nil
+	case reflect.Ptr:
+		el := dst.Elem()
+		res, err := d.initer(ctx, d, node, el.Type(), el)
+		if err != nil {
+			return nil, err
+		}
+
+		vOf := reflect.ValueOf(res)
+		if vOf.Type() != el.Type() {
+			var token *token.Token
+			if n, ok := node.(ast.Node); ok {
+				token = n.GetToken()
+			}
+
+			return nil, errors.ErrTypeMismatch(el.Type(), vOf.Type(), token)
+		}
+
+		el.Set(vOf)
+
+		return dst.Interface(), nil
+	}
+
+	return reflect.New(t).Elem().Interface(), nil
+}
+
+func WithIniter(i Initer) DecodeOption {
+	return func(d *Decoder) error {
+		if i == nil {
+			i = DefaultInitier
+		}
+
+		d.initer = i
+
 		return nil
 	}
 }


### PR DESCRIPTION
In some cases, special initialization of slices, structs, and maps is required. For example, allocating a slice from sync.Pool or setting default values ​​for structs in a slice where the number of elements is unknown in advance, so that the external YAML file does not contain anchor tags, etc.

Of course, you can use StructValidator, but it has a number of drawbacks, such as:
- Setting default values ​​is incorrect, as it modifies the structure being validated, as this operation should have no side effects.
- The user may have set a default value of zero for a type, in which case we will overwrite it. This means that default values ​​should be set before actual unmarshalling, not after, as is the case with a validator.

Custom unmarshalers can also be used to set default values, but this requires a significant amount of duplicate code that must be maintained as new types are added.

You can use something like https://github.com/mcuadros/go-defaults to set default values, eliminating the need to add wrappers or custom marshalers.

An initator is used to implement the pool/default values.

During initialization, it's often necessary to know how the decoder was initialized, as this can depend on various situations. Therefore, methods for retrieving decoder settings were added.

No new tests were added, as the code is essentially already covered by existing tests.

- [ ] Describe the purpose for which you created this PR.  
- [ ] Create test code that corresponds to the modification