### PR TITLE
Make the connection between `Strict` and `DisallowUnknownField` explicit

### DIFF
--- a/option.go
+++ b/option.go
@@ -51,12 +51,9 @@ func Validator(v StructValidator) DecodeOption {
 	}
 }
 
-// Strict enable DisallowUnknownField
+// Strict is an alias for [DisallowUnknownField].
 func Strict() DecodeOption {
-	return func(d *Decoder) error {
-		d.disallowUnknownField = true
-		return nil
-	}
+	return DisallowUnknownField()
 }
 
 // DisallowUnknownField causes the Decoder to return an error when the destination


### PR DESCRIPTION
The two unmarshal options `Strict` and `DisallowUnknownField` are identical. But this has not been documented and also the implementation is cloned. 
Both points lead the investigating developer to wonder what the differences may be.

This PR now aliases `Strict` to `DisallowUnknownField`, both in documentation and implementation.