### PR TITLE
fix: Support line-comment for flow-style structures

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1279,13 +1279,6 @@ func (n *MappingNode) blockStyleString(commentMode bool) string {
 
 // String mapping values to text
 func (n *MappingNode) String() string {
-	if len(n.Values) == 0 {
-		if n.Comment != nil {
-			return addCommentString("{}", n.Comment)
-		}
-		return "{}"
-	}
-
 	commentMode := true
 	if n.IsFlowStyle || len(n.Values) == 0 {
 		return n.flowStyleString(commentMode)
@@ -1623,7 +1616,11 @@ func (n *SequenceNode) flowStyleString() string {
 	for _, value := range n.Values {
 		values = append(values, value.String())
 	}
-	return fmt.Sprintf("[%s]", strings.Join(values, ", "))
+	seqText := fmt.Sprintf("[%s]", strings.Join(values, ", "))
+	if n.Comment != nil {
+		return addCommentString(seqText, n.Comment)
+	}
+	return seqText
 }
 
 func (n *SequenceNode) blockStyleString() string {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -426,6 +426,9 @@ func (p *parser) parseFlowMap(ctx *context) (*ast.MappingNode, error) {
 	if node.End == nil {
 		return nil, errors.ErrSyntax("could not find flow mapping end token '}'", node.Start)
 	}
+	if err := setLineComment(ctx, node, ctx.currentToken()); err != nil {
+		return nil, err
+	}
 	ctx.goNext() // skip mapping end token.
 	return node, nil
 }
@@ -1065,6 +1068,9 @@ func (p *parser) parseFlowSequence(ctx *context) (*ast.SequenceNode, error) {
 	}
 	if node.End == nil {
 		return nil, errors.ErrSyntax("sequence end token ']' not found", node.Start)
+	}
+	if err := setLineComment(ctx, node, ctx.currentToken()); err != nil {
+		return nil, err
 	}
 	ctx.goNext() // skip sequence end token.
 	return node, nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1573,6 +1573,32 @@ elem1:
 `,
 		},
 		{
+			name: "flow sequence with line comment",
+			yaml: `
+elem1:
+  - elem2: [a, b, c, d] # comment
+    empty: [] # empty
+`,
+			expected: `
+elem1:
+  - elem2: [a, b, c, d] # comment
+    empty: [] # empty
+`,
+		},
+		{
+			name: "flow map with line comment",
+			yaml: `
+elem1:
+  - elem2: {a: b, c: d} # comment
+    empty: {} # empty
+`,
+			expected: `
+elem1:
+  - elem2: {a: b, c: d} # comment
+    empty: {} # empty
+`,
+		},
+		{
 			name: "literal",
 			yaml: `
 foo: | # comment


### PR DESCRIPTION
- Remove redundant empty mapping node check
- Add line comment support for flow mapping and sequence nodes
- Add test cases for flow sequence and map with line comments


Fix #818