### PR TITLE
Support custom unmarshallers for interface types

### DIFF
--- a/option.go
+++ b/option.go
@@ -220,8 +220,9 @@ func UseJSONMarshaler() EncodeOption {
 // the CustomMarshaler specified in EncodeOption takes precedence.
 func CustomMarshaler[T any](marshaler func(T) ([]byte, error)) EncodeOption {
 	return func(e *Encoder) error {
-		var typ T
-		e.customMarshalerMap[reflect.TypeOf(typ)] = func(ctx context.Context, v interface{}) ([]byte, error) {
+		typ := new(T)
+		rtyp := reflect.Indirect(reflect.ValueOf(typ)).Type()
+		e.customMarshalerMap[rtyp] = func(ctx context.Context, v interface{}) ([]byte, error) {
 			return marshaler(v.(T))
 		}
 		return nil
@@ -232,8 +233,9 @@ func CustomMarshaler[T any](marshaler func(T) ([]byte, error)) EncodeOption {
 // Similar to CustomMarshaler, but allows passing a context to the marshaler function.
 func CustomMarshalerContext[T any](marshaler func(context.Context, T) ([]byte, error)) EncodeOption {
 	return func(e *Encoder) error {
-		var typ T
-		e.customMarshalerMap[reflect.TypeOf(typ)] = func(ctx context.Context, v interface{}) ([]byte, error) {
+		typ := new(T)
+		rtyp := reflect.Indirect(reflect.ValueOf(typ)).Type()
+		e.customMarshalerMap[rtyp] = func(ctx context.Context, v interface{}) ([]byte, error) {
 			return marshaler(ctx, v.(T))
 		}
 		return nil

--- a/testdata/yaml_test.go
+++ b/testdata/yaml_test.go
@@ -1083,6 +1083,26 @@ func TestRegisterCustomMarshaler(t *testing.T) {
 	if !bytes.Equal(b, []byte("\"override\"\n")) {
 		t.Fatalf("failed to register custom marshaler. got: %q", b)
 	}
+	// Test using an interface override
+	type I interface{}
+	yaml.RegisterCustomMarshaler[I](func(_ I) ([]byte, error) {
+		return []byte(`"interface"`), nil
+	})
+	b, err = yaml.Marshal(&struct{ Interfaced I }{&T{Foo: []byte("bar")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(b, []byte("interfaced: \"interface\"\n")) {
+		t.Fatalf("failed to register custom marshaler. expected \"interface\" got: %q", b)
+	}
+	// Prove that straight pointer unmarshalling is unaffected
+	b, err = yaml.Marshal(&T{Foo: []byte("bar")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(b, []byte("\"override\"\n")) {
+		t.Fatalf("failed to register custom marshaler. got: %q", b)
+	}
 }
 
 func TestRegisterCustomMarshalerContext(t *testing.T) {

--- a/yaml.go
+++ b/yaml.go
@@ -280,8 +280,9 @@ func RegisterCustomMarshaler[T any](marshaler func(T) ([]byte, error)) {
 	globalCustomMarshalerMu.Lock()
 	defer globalCustomMarshalerMu.Unlock()
 
-	var typ T
-	globalCustomMarshalerMap[reflect.TypeOf(typ)] = func(ctx context.Context, v interface{}) ([]byte, error) {
+	typ := new(T)
+	rtyp := reflect.Indirect(reflect.ValueOf(typ)).Type()
+	globalCustomMarshalerMap[rtyp] = func(ctx context.Context, v interface{}) ([]byte, error) {
 		return marshaler(v.(T))
 	}
 }


### PR DESCRIPTION
The custom unmarshaller code did not handle being passed a nil interface properly, meaning doing so would lead to "nil" being assigned an unmarshaller and the interface type not being.

This patch fixes this to allow interface types to have custom unmarshallers assigned, which allows code like:

```
type S struct {
    X SomeInterface
}
```

to be detected and unmarshalled using a custom unmarshaller.

It should be noted that direct variables must be passed by address to be detected e.g.

```
var S SomeInterface
yaml.Unmarshal(bytes, &S)
```

The specific utility of this code is that it provides the ability to set custom serialization for types with interface members such that they can be directly unmarshalled back to the interface (for example, by using a discriminant enum).