### PR TITLE
fix: preserve LiteralNode content indentation in Replace operations

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -908,6 +908,43 @@ func (n *LiteralNode) AddColumn(col int) {
 	}
 }
 
+// detectIndent returns the leading whitespace count of the first non-empty
+// content line in a node's Origin. For LiteralNode, it examines the Value's
+// Origin; for other nodes, it examines the node's own token Origin.
+func detectIndent(node Node) int {
+	var origin string
+	if ln, ok := node.(*LiteralNode); ok && ln.Value != nil {
+		origin = ln.Value.GetToken().Origin
+	} else {
+		origin = node.GetToken().Origin
+	}
+	for _, line := range strings.Split(origin, "\n") {
+		trimmed := strings.TrimLeft(line, " ")
+		if trimmed != "" {
+			return len(line) - len(trimmed)
+		}
+	}
+	return 0
+}
+
+// rebuildLiteralOrigin reconstructs the Origin text of a literal block scalar's
+// content token from its Value string and the target indentation level.
+func rebuildLiteralOrigin(tk *token.Token, targetIndent int) {
+	indent := strings.Repeat(" ", targetIndent)
+	lines := strings.Split(tk.Value, "\n")
+	var sb strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		if line != "" {
+			sb.WriteString(indent)
+			sb.WriteString(line)
+		}
+	}
+	tk.Origin = sb.String()
+}
+
 // GetValue returns string value
 func (n *LiteralNode) GetValue() interface{} {
 	return n.String()
@@ -1374,6 +1411,23 @@ type MappingValueNode struct {
 // Replace replace value node.
 func (n *MappingValueNode) Replace(value Node) error {
 	column := n.Value.GetToken().Position.Column - value.GetToken().Position.Column
+	switch v := value.(type) {
+	case *MappingNode:
+		column = n.Key.GetToken().Position.Column + 2 - v.startPos().Column
+	case *SequenceNode:
+		column = n.Key.GetToken().Position.Column + 2 - v.GetToken().Position.Column
+	case *StringNode:
+		if strings.ContainsAny(v.Value, "\n\r") {
+			column = n.Key.GetToken().Position.Column - v.GetToken().Position.Column
+		}
+	case *LiteralNode:
+		column = n.Key.GetToken().Position.Column - v.GetToken().Position.Column
+		targetIndent := detectIndent(n.Value)
+		if targetIndent == 0 {
+			targetIndent = n.Key.GetToken().Position.Column - 1 + 2
+		}
+		rebuildLiteralOrigin(v.Value.GetToken(), targetIndent)
+	}
 	value.AddColumn(column)
 	n.Value = value
 	return nil
@@ -1564,6 +1618,22 @@ func (n *SequenceNode) Replace(idx int, value Node) error {
 		)
 	}
 	column := n.Values[idx].GetToken().Position.Column - value.GetToken().Position.Column
+	switch v := value.(type) {
+	case *MappingNode:
+		column = n.Values[idx].GetToken().Position.Column - v.startPos().Column
+	case *SequenceNode:
+		column = n.Values[idx].GetToken().Position.Column - v.GetToken().Position.Column
+	case *StringNode:
+		if strings.ContainsAny(v.Value, "\n\r") {
+			column = n.Values[idx].GetToken().Position.Column - value.GetToken().Position.Column
+		}
+	case *LiteralNode:
+		targetIndent := detectIndent(n.Values[idx])
+		if targetIndent == 0 {
+			targetIndent = n.Start.Position.Column - 1 + 2
+		}
+		rebuildLiteralOrigin(v.Value.GetToken(), targetIndent)
+	}
 	value.AddColumn(column)
 	n.Values[idx] = value
 	return nil

--- a/path_test.go
+++ b/path_test.go
@@ -862,6 +862,285 @@ building:
 	}
 }
 
+func TestPath_ReplaceWithNode_ValueToNodeIndent(t *testing.T) {
+	path, err := yaml.PathString("$.b")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	file, err := parser.ParseBytes([]byte(`
+a: 1
+b:
+  c: 2
+`), 0)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	node, err := yaml.ValueToNode(map[string]int{"d": 3})
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err := path.ReplaceWithNode(file, node); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	expected := `
+a: 1
+b:
+  d: 3
+`
+	actual := "\n" + file.String()
+	if expected != actual {
+		t.Fatalf("expected: %q. but got %q", expected, actual)
+	}
+}
+
+func TestPath_ReplaceWithNode_LiteralNodeIndent(t *testing.T) {
+	path, err := yaml.PathString("$.spec.files[0].content")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	file, err := parser.ParseBytes([]byte(`
+spec:
+  files:
+    - path: a.txt
+      content: |
+        old content
+    - path: b.txt
+      content: |
+        name: CI
+`), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	node, err := yaml.ValueToNode("first line\nsecond line\n", yaml.UseLiteralStyleIfMultiline(true))
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err := path.ReplaceWithNode(file, node); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	expected := `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        first line
+        second line
+    - path: b.txt
+      content: |
+        name: CI
+`
+	actual := "\n" + file.String()
+	if expected != actual {
+		t.Fatalf("expected: %q. but got %q", expected, actual)
+	}
+}
+
+func TestPath_ReplaceWithParsedLiteralNodeIndent(t *testing.T) {
+	path, err := yaml.PathString("$.spec.files[0].content")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	file, err := parser.ParseBytes([]byte(`
+spec:
+  files:
+    - path: a.txt
+      content: |
+        old content
+    - path: b.txt
+      content: |
+        name: CI
+`), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	valBytes, err := yaml.MarshalWithOptions("first line\nsecond line\n", yaml.UseLiteralStyleIfMultiline(true))
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	valFile, err := parser.ParseBytes(valBytes, 0)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err := path.ReplaceWithNode(file, valFile.Docs[0].Body); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	expected := `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        first line
+        second line
+    - path: b.txt
+      content: |
+        name: CI
+`
+	actual := "\n" + file.String()
+	if expected != actual {
+		t.Fatalf("expected: %q. but got %q", expected, actual)
+	}
+}
+
+func TestPath_ReplaceWithParsedLiteralNodeIndent_MultipleMatches(t *testing.T) {
+	path, err := yaml.PathString("$.spec.files[*].content")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	file, err := parser.ParseBytes([]byte(`
+spec:
+  files:
+    - path: a.txt
+      content: |
+        old content
+    - path: b.txt
+      content: |
+        name: CI
+`), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	valBytes, err := yaml.MarshalWithOptions("first line\nsecond line\n", yaml.UseLiteralStyleIfMultiline(true))
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	valFile, err := parser.ParseBytes(valBytes, 0)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err := path.ReplaceWithNode(file, valFile.Docs[0].Body); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	expected := `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        first line
+        second line
+    - path: b.txt
+      content: |
+        first line
+        second line
+`
+	actual := "\n" + file.String()
+	if expected != actual {
+		t.Fatalf("expected: %q. but got %q", expected, actual)
+	}
+}
+
+func TestPath_ReplaceWithParsedLiteralNodeIndent_SpecialCharacters(t *testing.T) {
+	path, err := yaml.PathString("$.spec.files[0].content")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	file, err := parser.ParseBytes([]byte(`
+spec:
+  files:
+    - path: a.txt
+      content: |
+        old content
+    - path: b.txt
+      content: |
+        name: CI
+`), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	value := "* item\n/path/ @group\nkey: value\n"
+	valBytes, err := yaml.MarshalWithOptions(value, yaml.UseLiteralStyleIfMultiline(true))
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	valFile, err := parser.ParseBytes(valBytes, 0)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err := path.ReplaceWithNode(file, valFile.Docs[0].Body); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	expected := `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        * item
+        /path/ @group
+        key: value
+    - path: b.txt
+      content: |
+        name: CI
+`
+	actual := "\n" + file.String()
+	if expected != actual {
+		t.Fatalf("expected: %q. but got %q", expected, actual)
+	}
+}
+
+func TestPath_ReplaceSequenceElementWithParsedLiteralNodeIndent(t *testing.T) {
+	path, err := yaml.PathString("$.items[0]")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	file, err := parser.ParseBytes([]byte(`
+items:
+  - |
+    old content
+  - |
+    name: CI
+`), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	valBytes, err := yaml.MarshalWithOptions("* item\n/path/ @group\nkey: value\n", yaml.UseLiteralStyleIfMultiline(true))
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	valFile, err := parser.ParseBytes(valBytes, 0)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if err := path.ReplaceWithNode(file, valFile.Docs[0].Body); err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	expected := `
+items:
+  - |
+    * item
+    /path/ @group
+    key: value
+  - |
+    name: CI
+`
+	actual := "\n" + file.String()
+	if expected != actual {
+		t.Fatalf("expected: %q. but got %q", expected, actual)
+	}
+}
+
 func TestInvalidPath(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Purpose

Fix `MappingValueNode.Replace` and `SequenceNode.Replace` corrupting literal block scalar (`|`) content when replacing nodes. Characters were eaten from the beginning of each content line because `AddColumn` adjusts `Position.Column` but `LiteralNode.String()` uses the raw `Origin` text, which was never updated to reflect the new position.

This was originally reported in #636.

### Root cause

`MappingValueNode.Replace` computes a column delta and calls `value.AddColumn(delta)`. For most node types, `String()` uses `Position.Column` to reconstruct output, so this works correctly. However, `LiteralNode.String()` ignores `Position.Column` entirely and returns the raw `Origin` text from the scanner. The `Origin` retains the indentation from the source document (the replacement value), not the destination, causing the mismatch.

### Fix

- In `MappingValueNode.Replace` and `SequenceNode.Replace`, recalculate the column delta for `MappingNode`, `SequenceNode`, multiline `StringNode`, and `LiteralNode` based on the key/parent column position rather than the value token position.
- For `LiteralNode`, rebuild the `Origin` text from the actual `Value` string with the correct target indentation. This avoids cumulative corruption when the same node is replaced into multiple locations (e.g. via `[*]` or `..` paths).

### Tests added

- `TestPath_ReplaceWithNode_ValueToNodeIndent`: MappingNode replacement via `ValueToNode` (#636 scenario)
- `TestPath_ReplaceWithNode_LiteralNodeIndent`: LiteralNode replacement via `ValueToNode`
- `TestPath_ReplaceWithParsedLiteralNodeIndent`: LiteralNode replacement via `parser.ParseBytes`
- `TestPath_ReplaceWithParsedLiteralNodeIndent_MultipleMatches`: `[*]` path replacing same node into multiple locations
- `TestPath_ReplaceWithParsedLiteralNodeIndent_SpecialCharacters`: content with YAML-special characters (`*`, `/`, `:`) at line beginnings
- `TestPath_ReplaceSequenceElementWithParsedLiteralNodeIndent`: `SequenceNode.Replace` with literal block scalar