### PR TITLE
fix(ast): preserve indentation when replacing block-style nodes

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -908,6 +908,81 @@ func (n *LiteralNode) AddColumn(col int) {
 	}
 }
 
+// detectLiteralContentIndent returns the leading whitespace count of the first
+// non-empty content line of a literal-style scalar value. It supports both
+// *LiteralNode (parsed via parser.ParseBytes) and multiline *StringNode
+// (produced by yaml.ValueToNode with UseLiteralStyleIfMultiline). It returns
+// 0 when the indent cannot be inferred from the node, in which case callers
+// should fall back to a sensible default.
+func detectLiteralContentIndent(node Node) int {
+	var origin string
+	switch n := node.(type) {
+	case *LiteralNode:
+		if n.Value != nil {
+			origin = n.Value.GetToken().Origin
+		}
+	case *StringNode:
+		if n.Token != nil {
+			origin = n.Token.Origin
+		}
+	}
+	if origin == "" {
+		return 0
+	}
+	for _, line := range strings.Split(origin, "\n") {
+		trimmed := strings.TrimLeft(line, " ")
+		if trimmed != "" {
+			return len(line) - len(trimmed)
+		}
+	}
+	return 0
+}
+
+// applyLiteralContentIndent re-indents the content of a literal-style scalar
+// value (a *LiteralNode or a multiline *StringNode) to the given target
+// indentation. For *LiteralNode, the inner string token's Origin is rebuilt
+// from its Value so the new lines do not inherit the source document's
+// indentation. For multiline *StringNode, the position is adjusted so that
+// String() emits content lines starting at the target indent.
+//
+// This function is a no-op for any node type that does not render as a
+// multiline literal-style scalar.
+func applyLiteralContentIndent(value Node, indent int) {
+	switch v := value.(type) {
+	case *LiteralNode:
+		if v.Value == nil {
+			return
+		}
+		tk := v.Value.GetToken()
+		pad := strings.Repeat(" ", indent)
+		lines := strings.Split(tk.Value, "\n")
+		var sb strings.Builder
+		for i, line := range lines {
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			// Empty entries (e.g. the trailing element from a final "\n")
+			// must remain empty so the literal block keeps its trailing
+			// newline; only non-empty lines get re-indented.
+			if line != "" {
+				sb.WriteString(pad)
+				sb.WriteString(line)
+			}
+		}
+		tk.Origin = sb.String()
+	case *StringNode:
+		if v.Token == nil || !strings.ContainsAny(v.Value, "\n\r") {
+			return
+		}
+		// StringNode.String() emits each content line as
+		//   strings.Repeat(" ", Column-1) + strings.Repeat(" ", IndentNum) + line
+		// so the total leading-space count is (Column-1) + IndentNum.
+		// Pin Column to 1 and let IndentNum carry the full indent.
+		v.Token.Position.Column = 1
+		v.Token.Position.IndentNum = indent
+	}
+}
+
 // GetValue returns string value
 func (n *LiteralNode) GetValue() interface{} {
 	return n.String()
@@ -1373,10 +1448,99 @@ type MappingValueNode struct {
 
 // Replace replace value node.
 func (n *MappingValueNode) Replace(value Node) error {
-	column := n.Value.GetToken().Position.Column - value.GetToken().Position.Column
-	value.AddColumn(column)
+	if isLiteralStyleScalar(value) {
+		// Literal block scalars are rendered from their original source
+		// indentation rather than from Position.Column, so the standard
+		// AddColumn-based shift used below cannot fix their indentation.
+		// Re-indent the content to match the destination instead.
+		fallback := n.Key.GetToken().Position.Column - 1 + 2
+		indent := detectLiteralContentIndent(n.Value)
+		if indent == 0 {
+			indent = fallback
+		}
+		applyLiteralContentIndent(value, indent)
+		n.Value = value
+		return nil
+	}
+	dstCol, srcCol := replaceColumns(n.Value, value, n.Key.GetToken().Position.Column+2)
+	value.AddColumn(dstCol - srcCol)
 	n.Value = value
 	return nil
+}
+
+// replaceColumns computes the (destination, source) column pair to use when
+// shifting `newValue` into the slot currently occupied by `existing`.
+//
+// For block-style *MappingNode and *SequenceNode replacements, both columns
+// are anchored at the first content position (the first key or the first
+// element). This is necessary because MappingNode.GetToken() returns the
+// internal Start token whose column is parser-dependent (often the first
+// colon), while ValueToNode-built mappings put Start at column 1 — using
+// either inconsistently would produce off-by-one indentation.
+//
+// For all other node types, both columns fall back to the standard token
+// position so that scalar→scalar replacements continue to align exactly with
+// the previous behavior.
+//
+// `convDefault` is the column to use as the destination when the existing
+// value cannot supply one (e.g. replacing a scalar with a block mapping):
+// it should be the natural indent for a block child of the parent (typically
+// parent_key_column + 2).
+func replaceColumns(existing, newValue Node, convDefault int) (dstCol, srcCol int) {
+	srcCol = anchorColumn(newValue)
+	dstCol = anchorColumn(existing)
+	// If the existing slot is a non-block value (scalar) but the new value
+	// is a block-style structure, the existing token column points just
+	// after `key: ` which would over-indent the new structure. Use the
+	// caller-supplied convention default instead.
+	if isBlockStructure(newValue) && !isBlockStructure(existing) {
+		dstCol = convDefault
+	}
+	return dstCol, srcCol
+}
+
+// anchorColumn returns the column where the node's content effectively
+// starts. For *MappingNode that is the first key's column (not the Start
+// token's column, which is parser-dependent); for *SequenceNode it is the
+// first element's column. For scalars and other nodes it is the node's
+// own token column.
+func anchorColumn(n Node) int {
+	switch v := n.(type) {
+	case *MappingNode:
+		if len(v.Values) > 0 {
+			return v.startPos().Column
+		}
+	case *SequenceNode:
+		if len(v.Values) > 0 {
+			return v.Values[0].GetToken().Position.Column
+		}
+	}
+	return n.GetToken().Position.Column
+}
+
+// isBlockStructure reports whether n renders as a block-style mapping or
+// sequence (i.e. its content lives on lines below the parent key).
+func isBlockStructure(n Node) bool {
+	switch v := n.(type) {
+	case *MappingNode:
+		return !v.IsFlowStyle && len(v.Values) > 0
+	case *SequenceNode:
+		return !v.IsFlowStyle && len(v.Values) > 0
+	}
+	return false
+}
+
+// isLiteralStyleScalar reports whether n renders as a multiline literal-style
+// scalar (i.e. a *LiteralNode, or a *StringNode whose Value contains a line
+// break and is therefore emitted via the literal block path in String()).
+func isLiteralStyleScalar(n Node) bool {
+	switch v := n.(type) {
+	case *LiteralNode:
+		return true
+	case *StringNode:
+		return strings.ContainsAny(v.Value, "\n\r")
+	}
+	return false
 }
 
 // Read implements (io.Reader).Read
@@ -1563,8 +1727,21 @@ func (n *SequenceNode) Replace(idx int, value Node) error {
 			len(n.Values), idx,
 		)
 	}
-	column := n.Values[idx].GetToken().Position.Column - value.GetToken().Position.Column
-	value.AddColumn(column)
+	if isLiteralStyleScalar(value) {
+		// See MappingValueNode.Replace for the rationale: literal block
+		// scalars need their content re-indented at replacement time
+		// because their rendering bypasses Position.Column.
+		fallback := n.Start.Position.Column - 1 + 2
+		indent := detectLiteralContentIndent(n.Values[idx])
+		if indent == 0 {
+			indent = fallback
+		}
+		applyLiteralContentIndent(value, indent)
+		n.Values[idx] = value
+		return nil
+	}
+	dstCol, srcCol := replaceColumns(n.Values[idx], value, n.Start.Position.Column+2)
+	value.AddColumn(dstCol - srcCol)
 	n.Values[idx] = value
 	return nil
 }

--- a/path_test.go
+++ b/path_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
 )
 
@@ -860,6 +861,293 @@ building:
 			})
 		})
 	}
+}
+
+func TestPath_ReplaceWithNode_PreserveIndent(t *testing.T) {
+	// Each case feeds either a node produced by yaml.ValueToNode (which yields
+	// a *ast.StringNode for literal-style multiline strings) or a node parsed
+	// out of YAML text (which yields a *ast.LiteralNode), and verifies that
+	// the destination document's indentation is preserved after replacement.
+	//
+	// The matrix exists because the two construction paths produce different
+	// AST node types and the replacement code path must handle both. The
+	// non-2-space cases guard against regressions where the indent was being
+	// silently normalized to 2 spaces.
+	tests := []struct {
+		name     string
+		path     string
+		src      string
+		newNode  func(t *testing.T) ast.Node
+		expected string
+	}{
+		{
+			// Originally reported in #636.
+			name: "mapping replacement (2-space indent)",
+			path: "$.b",
+			src: `
+a: 1
+b:
+  c: 2
+`,
+			newNode: func(t *testing.T) ast.Node {
+				n, err := yaml.ValueToNode(map[string]int{"d": 3})
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return n
+			},
+			expected: `
+a: 1
+b:
+  d: 3
+`,
+		},
+		{
+			name: "mapping replacement (4-space indent must be preserved)",
+			path: "$.b",
+			src: `
+a: 1
+b:
+    c: 2
+`,
+			newNode: func(t *testing.T) ast.Node {
+				n, err := yaml.ValueToNode(map[string]int{"d": 3})
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return n
+			},
+			expected: `
+a: 1
+b:
+    d: 3
+`,
+		},
+		{
+			name: "literal replacement via ValueToNode (StringNode path)",
+			path: "$.spec.files[0].content",
+			src: `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        old content
+    - path: b.txt
+      content: |
+        name: CI
+`,
+			newNode: func(t *testing.T) ast.Node {
+				n, err := yaml.ValueToNode(
+					"first line\nsecond line\n",
+					yaml.UseLiteralStyleIfMultiline(true),
+				)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return n
+			},
+			expected: `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        first line
+        second line
+    - path: b.txt
+      content: |
+        name: CI
+`,
+		},
+		{
+			name: "literal replacement via parser.ParseBytes (LiteralNode path)",
+			path: "$.spec.files[0].content",
+			src: `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        old content
+    - path: b.txt
+      content: |
+        name: CI
+`,
+			newNode: func(t *testing.T) ast.Node {
+				return mustParseLiteral(t, "first line\nsecond line\n")
+			},
+			expected: `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        first line
+        second line
+    - path: b.txt
+      content: |
+        name: CI
+`,
+		},
+		{
+			name: "literal replacement via [*] applies to multiple slots without cumulative corruption",
+			path: "$.spec.files[*].content",
+			src: `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        old content
+    - path: b.txt
+      content: |
+        name: CI
+`,
+			newNode: func(t *testing.T) ast.Node {
+				return mustParseLiteral(t, "first line\nsecond line\n")
+			},
+			expected: `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        first line
+        second line
+    - path: b.txt
+      content: |
+        first line
+        second line
+`,
+		},
+		{
+			name: "literal content with YAML-special characters at line starts",
+			path: "$.spec.files[0].content",
+			src: `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        old content
+    - path: b.txt
+      content: |
+        name: CI
+`,
+			newNode: func(t *testing.T) ast.Node {
+				return mustParseLiteral(t, "* item\n/path/ @group\nkey: value\n")
+			},
+			expected: `
+spec:
+  files:
+    - path: a.txt
+      content: |
+        * item
+        /path/ @group
+        key: value
+    - path: b.txt
+      content: |
+        name: CI
+`,
+		},
+		{
+			name: "sequence element replacement with literal (LiteralNode path)",
+			path: "$.items[0]",
+			src: `
+items:
+  - |
+    old content
+  - |
+    name: CI
+`,
+			newNode: func(t *testing.T) ast.Node {
+				return mustParseLiteral(t, "* item\n/path/ @group\nkey: value\n")
+			},
+			expected: `
+items:
+  - |
+    * item
+    /path/ @group
+    key: value
+  - |
+    name: CI
+`,
+		},
+		{
+			// Guards against the StringNode-vs-LiteralNode classification gap:
+			// yaml.ValueToNode returns *StringNode and the source uses a
+			// non-default indent. Without the StringNode side of the fix, the
+			// new content would be re-indented to 2 spaces and silently lose
+			// the source document's indentation contract.
+			name: "literal replacement preserves non-2-space indent (StringNode path)",
+			path: "$.content",
+			src: `
+content: |
+   indented3
+`,
+			newNode: func(t *testing.T) ast.Node {
+				n, err := yaml.ValueToNode(
+					"AAA\nBBB\n",
+					yaml.UseLiteralStyleIfMultiline(true),
+				)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				return n
+			},
+			expected: `
+content: |
+   AAA
+   BBB
+`,
+		},
+		{
+			name: "literal replacement preserves non-2-space indent (LiteralNode path)",
+			path: "$.content",
+			src: `
+content: |
+   indented3
+`,
+			newNode: func(t *testing.T) ast.Node {
+				return mustParseLiteral(t, "AAA\nBBB\n")
+			},
+			expected: `
+content: |
+   AAA
+   BBB
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := yaml.PathString(tt.path)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			file, err := parser.ParseBytes([]byte(tt.src), parser.ParseComments)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			node := tt.newNode(t)
+			if err := path.ReplaceWithNode(file, node); err != nil {
+				t.Fatalf("%+v", err)
+			}
+			actual := "\n" + file.String()
+			if tt.expected != actual {
+				t.Fatalf("expected: %q\nbut got:  %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+// mustParseLiteral marshals s as a literal-style block scalar and parses the
+// result back so the returned node is a *ast.LiteralNode rather than a
+// *ast.StringNode (the two go through different replacement code paths).
+func mustParseLiteral(t *testing.T, s string) ast.Node {
+	t.Helper()
+	b, err := yaml.MarshalWithOptions(s, yaml.UseLiteralStyleIfMultiline(true))
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	f, err := parser.ParseBytes(b, 0)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	return f.Docs[0].Body
 }
 
 func TestInvalidPath(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes two related defects in `MappingValueNode.Replace` / `SequenceNode.Replace` that caused wrong indentation in the resulting document.

This is an alternative implementation of #864 that I found while reviewing it. It addresses the same root issue (#636) but covers two paths #864 missed and avoids a regression for non-2-space indented documents. Closes #864 in spirit — happy to either merge this and close #864, or merge #864 and follow up here.

## Bugs fixed

### 1. Literal block scalars (`|`) lost their indentation on replace

`LiteralNode.String()` and the multiline path of `StringNode.String()` bypass `Position.Column` and render from their original `Origin` / inner indent. Replacing such a value via either construction path therefore left the new content indented at the source column, not the destination column:

- `parser.ParseBytes` of `key: |\n  content` returns a `*ast.LiteralNode`
- `yaml.ValueToNode(s, yaml.UseLiteralStyleIfMultiline(true))` returns a `*ast.StringNode` with `Value` containing `\n`

#864 fixed only the `*LiteralNode` path. The added test that exercised the `*StringNode` path passed only by accident — its source happened to use 2-space indentation that aligned with `IndentNum`'s default — so the bug remained latent for any document that uses a different indent.

### 2. Block-style mapping/sequence replacements were off-by-one

The previous code used `value.GetToken().Position.Column` as both the source and destination anchor. But `*MappingNode.GetToken()` returns the parser-internal `Start` token, whose column varies between parser-built nodes (often points at the first colon) and `ValueToNode`-built nodes (always column 1). Replacing a parser-built mapping with a `ValueToNode`-built mapping silently produced 3-space indent for a 2-space source, 5-space for 4-space, etc.

#864 papered over this with a hardcoded `+2` which made the 2-space case work but regressed documents using any other indent.

## Fix

Two small helper sets in `ast/ast.go`:

- **`detectLiteralContentIndent`** / **`applyLiteralContentIndent`** — for `*LiteralNode`, rebuild the inner string token's `Origin` from its `Value` with the target indent; for multiline `*StringNode`, pin `Position.Column = 1` and `Position.IndentNum = targetIndent` so `String()` emits content at the right column. The rebuild path is idempotent across repeated replacements (e.g. `[*]` paths), so reusing the same parsed node into multiple slots no longer accumulates corruption.
- **`replaceColumns`** / **`anchorColumn`** / **`isBlockStructure`** — compute the column delta from each node's first content position (first key for `*MappingNode`, first element for `*SequenceNode`) rather than from `Start.Column`, so block-style replacements work consistently regardless of how the value was constructed. When a scalar slot is being replaced by a block structure (no source-side indent to inherit), the caller-supplied `parent_key + 2` convention default is used.

Both `MappingValueNode.Replace` and `SequenceNode.Replace` now route literal-style scalars through the re-indent helpers and route block-style structures through the column-delta helpers.

## Tests

Adds `TestPath_ReplaceWithNode_PreserveIndent` (table-driven) in `path_test.go` covering:

- Mapping replacement via `ValueToNode` (2-space — the #636 scenario)
- Mapping replacement via `ValueToNode` (4-space — guards against the #864 regression)
- Literal replacement via `ValueToNode` (`*StringNode` path)
- Literal replacement via `parser.ParseBytes` (`*LiteralNode` path)
- `[*]` multi-slot literal replacement (no cumulative corruption)
- Literal content with YAML-special characters (`*`, `/`, `:`) at line starts
- Sequence element literal replacement
- Literal replacement preserving non-2-space (3-space) source indent on both construction paths — guards against the latent `*StringNode` gap

All existing tests in the repo pass unchanged.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] New regression tests cover both `*LiteralNode` and `*StringNode` construction paths
- [x] Existing `TestPath_Replace` (the case that originally relied on the parser quirk) still passes

Refs #636, #864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
