### PR TITLE
Provide option for strict int type checking to avoid precision loss

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -47,6 +47,7 @@ type Decoder struct {
 	parsedFile           *ast.File
 	streamIndex          int
 	decodeDepth          int
+	strictIntTypes       bool
 }
 
 // NewDecoder returns a new decoder that reads from r.
@@ -65,6 +66,7 @@ func NewDecoder(r io.Reader, opts ...DecodeOption) *Decoder {
 		disallowUnknownField: false,
 		allowDuplicateMapKey: false,
 		useOrderedMap:        false,
+		strictIntTypes:       false,
 	}
 }
 
@@ -978,12 +980,18 @@ func (d *Decoder) decodeValue(ctx context.Context, dst reflect.Value, src ast.No
 			}
 		case float64:
 			if vv <= math.MaxInt64 && !dst.OverflowInt(int64(vv)) {
+				if err := d.validateStrictIntValue(src, valueType, vv); err != nil {
+					return err
+				}
 				dst.SetInt(int64(vv))
 				return nil
 			}
 		case string: // handle scientific notation
 			if i, err := strconv.ParseFloat(vv, 64); err == nil {
 				if 0 <= i && i <= math.MaxUint64 && !dst.OverflowInt(int64(i)) {
+					if err := d.validateStrictIntValue(src, valueType, i); err != nil {
+						return err
+					}
 					dst.SetInt(int64(i))
 					return nil
 				}
@@ -1012,12 +1020,18 @@ func (d *Decoder) decodeValue(ctx context.Context, dst reflect.Value, src ast.No
 			}
 		case float64:
 			if 0 <= vv && vv <= math.MaxUint64 && !dst.OverflowUint(uint64(vv)) {
+				if err := d.validateStrictIntValue(src, valueType, vv); err != nil {
+					return err
+				}
 				dst.SetUint(uint64(vv))
 				return nil
 			}
 		case string: // handle scientific notation
 			if i, err := strconv.ParseFloat(vv, 64); err == nil {
 				if 0 <= i && i <= math.MaxUint64 && !dst.OverflowUint(uint64(i)) {
+					if err := d.validateStrictIntValue(src, valueType, i); err != nil {
+						return err
+					}
 					dst.SetUint(uint64(i))
 					return nil
 				}
@@ -1041,6 +1055,13 @@ func (d *Decoder) decodeValue(ctx context.Context, dst reflect.Value, src ast.No
 			return err
 		}
 		dst.Set(convertedValue)
+	}
+	return nil
+}
+
+func (d *Decoder) validateStrictIntValue(src ast.Node, valueType reflect.Type, v float64) error {
+	if d.strictIntTypes && math.Trunc(v) != v {
+		return errors.ErrTypeMismatch(valueType, reflect.TypeOf(v), src.GetToken())
 	}
 	return nil
 }

--- a/option.go
+++ b/option.go
@@ -59,6 +59,13 @@ func Strict() DecodeOption {
 	}
 }
 
+func StrictInts() DecodeOption {
+	return func(d *Decoder) error {
+		d.strictIntTypes = true
+		return nil
+	}
+}
+
 // DisallowUnknownField causes the Decoder to return an error when the destination
 // is a struct and the input contains object keys which do not match any
 // non-ignored, exported fields in the destination.

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -401,6 +401,18 @@ key: "1.5e-4"
 	}
 }
 
+func TestScientificNotationWithStrictIntsAndPrecisionLossForUints(t *testing.T) {
+	yml := `
+key: "1.5e-4"
+`
+	var v struct {
+		Key uint64
+	}
+	if err := yaml.UnmarshalWithOptions([]byte(yml), &v, yaml.StrictInts()); err == nil {
+		t.Fatal("expected error for lossy float->int conversion, got nil")
+	}
+}
+
 func TestScientificNotationWithStrictInts(t *testing.T) {
 	yml := `
 key: "1.5e+4"

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -353,6 +353,54 @@ c:
 	checkJSONRawValue(t, m4["c"], map[string]string{"foo": "bar"})
 }
 
+func TestConversionWithStrictInts(t *testing.T) {
+	yml := `
+key: 1.0
+`
+	var v struct {
+		Key int32
+	}
+	if err := yaml.UnmarshalWithOptions([]byte(yml), &v, yaml.StrictInts()); err != nil {
+		t.Fatalf("unexpected error for conversion %v", err)
+	}
+}
+
+func TestPrecisionLossWithStrictInts(t *testing.T) {
+	yml := `
+key: 1.5
+`
+	var v struct {
+		Key int64
+	}
+	if err := yaml.UnmarshalWithOptions([]byte(yml), &v, yaml.StrictInts()); err == nil {
+		t.Fatal("expected error for lossy float->int conversion, got nil")
+	}
+}
+
+func TestScientificNotationWithStrictIntsAndPrecisionLoss(t *testing.T) {
+	yml := `
+key: "1.5e-4"
+`
+	var v struct {
+		Key int64
+	}
+	if err := yaml.UnmarshalWithOptions([]byte(yml), &v, yaml.StrictInts()); err == nil {
+		t.Fatal("expected error for lossy float->int conversion, got nil")
+	}
+}
+
+func TestScientificNotationWithStrictInts(t *testing.T) {
+	yml := `
+key: "1.5e+4"
+`
+	var v struct {
+		Key int32
+	}
+	if err := yaml.UnmarshalWithOptions([]byte(yml), &v, yaml.StrictInts()); err != nil {
+		t.Fatalf("unexpected error for conversion %v", err)
+	}
+}
+
 type rawYAMLWrapper struct {
 	StaticField  string          `json:"staticField" yaml:"staticField"`
 	DynamicField yaml.RawMessage `json:"dynamicField" yaml:"dynamicField"`

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -377,6 +377,18 @@ key: 1.5
 	}
 }
 
+func TestPrecisionLossWithStrictIntsForUints(t *testing.T) {
+	yml := `
+key: 1.5
+`
+	var v struct {
+		Key uint64
+	}
+	if err := yaml.UnmarshalWithOptions([]byte(yml), &v, yaml.StrictInts()); err == nil {
+		t.Fatal("expected error for lossy float->int conversion, got nil")
+	}
+}
+
 func TestScientificNotationWithStrictIntsAndPrecisionLoss(t *testing.T) {
 	yml := `
 key: "1.5e-4"
@@ -395,6 +407,18 @@ key: "1.5e+4"
 `
 	var v struct {
 		Key int32
+	}
+	if err := yaml.UnmarshalWithOptions([]byte(yml), &v, yaml.StrictInts()); err != nil {
+		t.Fatalf("unexpected error for conversion %v", err)
+	}
+}
+
+func TestScientificNotationWithStrictIntsForUints(t *testing.T) {
+	yml := `
+key: "1.5e+4"
+`
+	var v struct {
+		Key uint32
 	}
 	if err := yaml.UnmarshalWithOptions([]byte(yml), &v, yaml.StrictInts()); err != nil {
 		t.Fatalf("unexpected error for conversion %v", err)


### PR DESCRIPTION
fixes https://github.com/goccy/go-yaml/issues/868

This PR introduces a StrictIntType option for decoding. When the option is set, conversions to int values will be strictly checked to prevent precision loss.

For purpose, please refer: https://github.com/goccy/go-yaml/issues/868