### PR TITLE
fix(decoder): inline map field no longer captures already-decoded struct fields

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1377,6 +1377,9 @@ func (d *Decoder) decodeStruct(ctx context.Context, dst reflect.Value, src ast.N
 			}
 			mapNode := ast.Mapping(nil, false)
 			for k, v := range keyToNodeMap {
+				if structFieldMap.isIncludedRenderName(k) {
+					continue
+				}
 				key := &ast.StringNode{BaseNode: &ast.BaseNode{}, Value: k}
 				mapNode.Values = append(mapNode.Values, ast.MappingValue(nil, key, v))
 			}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1852,6 +1852,27 @@ c: true
 	}
 }
 
+func TestDecoder_InlineMapExcludesKnownFields(t *testing.T) {
+	type Foo struct {
+		ID    string                 `yaml:"id"`
+		Extra map[string]interface{} `yaml:",inline"`
+	}
+	yml := "id: abc\nname: bar\n"
+	var v Foo
+	if err := yaml.NewDecoder(strings.NewReader(yml)).Decode(&v); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.ID != "abc" {
+		t.Fatalf("expected ID=abc, got %q", v.ID)
+	}
+	if _, ok := v.Extra["id"]; ok {
+		t.Fatal("inline map must not contain already-decoded field 'id'")
+	}
+	if v.Extra["name"] != "bar" {
+		t.Fatalf("inline map should contain unknown field 'name', got %v", v.Extra["name"])
+	}
+}
+
 func TestDecoder_InlineAndWrongTypeStrict(t *testing.T) {
 	type Base struct {
 		A int


### PR DESCRIPTION
## Description

Closes #811

When a struct field is tagged `yaml:",inline"` and its type is a `map`,
the decoder was populating that map with **all** keys from the YAML
document — including keys that are already claimed by other named fields
on the same struct.

### Root cause

In `decodeStruct()` (`decode.go`), the inline-field path builds a
synthetic mapping node from `keyToNodeMap` (which holds every key in
the YAML document) and passes it to the recursive decoder for the inline
field's type:

```go
// Before this fix — ALL keys are added, no filtering
mapNode := ast.Mapping(nil, false)
for k, v := range keyToNodeMap {
    key := &ast.StringNode{BaseNode: &ast.BaseNode{}, Value: k}
    mapNode.Values = append(mapNode.Values, ast.MappingValue(nil, key, v))
}
```

This means a struct such as:

```go
type Foo struct {
    ID    string                 `yaml:"id"`
    Extra map[string]interface{} `yaml:",inline"`
}
```

decoding `{ id: abc, name: bar }` would produce
`Extra == map[string]interface{}{"id": "abc", "name": "bar"}` — `id` is
captured by both `Foo.ID` *and* `Foo.Extra`.

### Why this is inconsistent with the encoder

The encoder has always handled this correctly. In `encodeStruct()`
(`encode.go`), when an inline map field is serialised, each key is
checked against the struct's declared fields before being written:

```go
if fieldMap.isIncludedRenderName(keyName) {
    // if declared the same key name, skip encoding this field
    continue
}
```

The helper `StructFieldMap.isIncludedRenderName()` already existed in
`struct.go` for exactly this purpose. The decoder simply never called
it.

### Fix

Apply the same guard in the decoder: skip any key that is already
claimed by a non-inline named field on the struct before adding it to
the synthetic map node.

```go
mapNode := ast.Mapping(nil, false)
for k, v := range keyToNodeMap {
    if structFieldMap.isIncludedRenderName(k) {
        continue
    }
    key := &ast.StringNode{BaseNode: &ast.BaseNode{}, Value: k}
    mapNode.Values = append(mapNode.Values, ast.MappingValue(nil, key, v))
}
```

This restores encode/decode symmetry and matches the behaviour of
`encoding/json`'s equivalent `",inline"` / `",remain"` patterns.

---

- [x] Describe the purpose for which you created this PR.
- [x] Create test code that corresponds to the modification