### PR TITLE
fix(scanner): strip a leading UTF-8 BOM at stream start (#906)

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -34,6 +34,17 @@ func TestDecoder(t *testing.T) {
 		eof    bool
 	}{
 		{
+			// A UTF-8 BOM at the start of the stream is an encoding signature,
+			// not content, so the first key is "v" and not "\ufeffv" (#906).
+			source: "\ufeffv: hi\n",
+			value:  map[string]string{"v": "hi"},
+		},
+		{
+			// A BOM that is not at the start of the stream stays content.
+			source: "v: \"x\ufeffy\"\n",
+			value:  map[string]string{"v": "x\ufeffy"},
+		},
+		{
 			source: "v: hi\n",
 			value:  map[string]string{"v": "hi"},
 		},

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -1496,6 +1496,12 @@ func (s *Scanner) scan(ctx *Context) error {
 // Init prepares the scanner s to tokenize the text src by setting the scanner at the beginning of src.
 func (s *Scanner) Init(text string) {
 	src := []rune(text)
+	// A UTF-8 byte order mark (U+FEFF) at the start of the stream identifies
+	// the encoding and is not part of the content (YAML 1.2 §5.2), so drop a
+	// single leading BOM. A BOM anywhere else is preserved as content.
+	if len(src) > 0 && src[0] == '\uFEFF' {
+		src = src[1:]
+	}
 	s.source = src
 	s.sourcePos = 0
 	s.sourceSize = len(src)


### PR DESCRIPTION
## What

Closes #906.

A UTF-8 byte order mark (`U+FEFF`, bytes `EF BB BF`) at the start of a stream is an encoding signature and is **not** content per [YAML 1.2 §5.2](https://yaml.org/spec/1.2.2/#52-character-encodings). The scanner read the source without stripping it, so the BOM became part of the first token:

```go
src := []byte("\ufeffa: 1\n")
var v any
yaml.Unmarshal(src, &v)
// got:      map[string]interface {}{"\ufeffa":1}
// expected: map[string]interface {}{"a":1}
```

This affects files written by BOM-emitting editors on Windows.

## Fix

Drop a single leading `U+FEFF` in `Scanner.Init`, right after the source is converted to runes. Only the stream-start BOM is stripped; a BOM anywhere else in the stream is preserved as content.

```go
src := []rune(text)
if len(src) > 0 && src[0] == '\uFEFF' {
    src = src[1:]
}
```

## Tests

Added two cases to `TestDecoder` in `decode_test.go`:

- `"\ufeffv: hi\n"` → `{"v": "hi"}` (leading BOM stripped)
- `"v: \"x\ufeffy\"\n"` → `{"v": "x\ufeffy"}` (BOM mid-content preserved)

**Verified RED→GREEN:** without the fix, `TestDecoder/\ufeffv:_hi_` fails (the key decodes as `\ufeffv`); with the fix it passes.

## Validation (real results, Go)

- `go test ./...` — **all packages pass**.
- Manually verified leading BOM stripped, no-BOM unchanged, mid-content BOM preserved, and empty input still decodes without error.
- `gofmt -l` and `go vet ./scanner/` are clean.

Note: as the issue mentions, full UTF-16 BOM handling is out of scope; this covers the common UTF-8 case.
