### PR TITLE
fix(token): classify scientific-notation numbers without a mantissa dot as floats (#916)

### DIFF
--- a/roundtrip916_test.go
+++ b/roundtrip916_test.go
@@ -1,0 +1,34 @@
+package yaml_test
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+// Regression test for #916: a float64 in scientific notation must survive a
+// dynamic (map[string]any) Unmarshal -> Marshal -> Unmarshal roundtrip as a
+// float64, not decode back to a string.
+func TestRoundtripScientificNotationIssue916(t *testing.T) {
+	var before map[string]any
+	if err := yaml.Unmarshal([]byte("value: 100000000000000000000.\n"), &before); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := before["value"].(float64); !ok {
+		t.Fatalf("before: value = %T, want float64", before["value"])
+	}
+
+	encoded, err := yaml.Marshal(before)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var after map[string]any
+	if err := yaml.Unmarshal(encoded, &after); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := after["value"].(float64); !ok {
+		t.Fatalf("after: value = %T (%v), want float64; encoded = %q",
+			after["value"], after["value"], string(encoded))
+	}
+}

--- a/token/scientific_test.go
+++ b/token/scientific_test.go
@@ -3,7 +3,7 @@ package token
 import "testing"
 
 // Regression test for goccy/go-yaml#916: scientific-notation numbers without a
-// mantissa dot (e.g. "1e+20") must be recognised as floats so that a float64
+// mantissa dot (e.g. "1e+20") must be recognized as floats so that a float64
 // survives an Unmarshal -> Marshal -> Unmarshal roundtrip instead of decoding
 // back to a string.
 func TestToNumberScientificNotation(t *testing.T) {
@@ -34,7 +34,7 @@ func TestToNumberScientificNotation(t *testing.T) {
 	}
 }
 
-// stripSignAndUnderscore mirrors the normalisation toNumber applies before the
+// stripSignAndUnderscore mirrors the normalization toNumber applies before the
 // type switch, so the helper is exercised on the same input shape.
 func stripSignAndUnderscore(s string) string {
 	out := make([]byte, 0, len(s))

--- a/token/scientific_test.go
+++ b/token/scientific_test.go
@@ -1,0 +1,50 @@
+package token
+
+import "testing"
+
+// Regression test for goccy/go-yaml#916: scientific-notation numbers without a
+// mantissa dot (e.g. "1e+20") must be recognised as floats so that a float64
+// survives an Unmarshal -> Marshal -> Unmarshal roundtrip instead of decoding
+// back to a string.
+func TestToNumberScientificNotation(t *testing.T) {
+	floatCases := []string{
+		"1e+20", "1e20", "1E+20", "-1e+20", "1.5e+10", "1.0e+20",
+		"1E-5", "0e0", "9e9",
+	}
+	for _, s := range floatCases {
+		num := ToNumber(s)
+		if num == nil {
+			t.Errorf("ToNumber(%q) = nil, want a float number", s)
+			continue
+		}
+		if num.Type != NumberTypeFloat {
+			t.Errorf("ToNumber(%q).Type = %q, want %q", s, num.Type, NumberTypeFloat)
+		}
+	}
+
+	// Values that merely contain 'e'/'E' but are not scientific notation must
+	// not be treated as numbers.
+	notNumber := []string{
+		"e10", "1e", "1e+", "1ee5", "abc", "0x1e", "1.2.3e4", "1e1.5",
+	}
+	for _, s := range notNumber {
+		if hasDecimalExponent(stripSignAndUnderscore(s)) {
+			t.Errorf("hasDecimalExponent(%q) = true, want false", s)
+		}
+	}
+}
+
+// stripSignAndUnderscore mirrors the normalisation toNumber applies before the
+// type switch, so the helper is exercised on the same input shape.
+func stripSignAndUnderscore(s string) string {
+	out := make([]byte, 0, len(s))
+	if len(s) > 0 && (s[0] == '+' || s[0] == '-') {
+		s = s[1:]
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] != '_' {
+			out = append(out, s[i])
+		}
+	}
+	return string(out)
+}

--- a/token/token.go
+++ b/token/token.go
@@ -577,6 +577,54 @@ func isNumber(value string) bool {
 	return num != nil
 }
 
+// hasDecimalExponent reports whether s is a base-10 number written in
+// scientific notation, e.g. "1e20", "1e+20", "1.5E-3". The mantissa may or may
+// not contain a decimal point. This is used so that exponent forms without a
+// mantissa dot (which strconv.ParseFloat accepts) are classified as floats
+// rather than falling through to the integer/octal cases. Callers must strip
+// any 0x/0o/0b prefix first so the exponent 'e' is not confused with a hex
+// digit.
+func hasDecimalExponent(s string) bool {
+	i := strings.IndexAny(s, "eE")
+	if i <= 0 || i == len(s)-1 {
+		// No exponent marker, nothing before it, or nothing after it.
+		return false
+	}
+	mantissa, exp := s[:i], s[i+1:]
+
+	// Mantissa: digits with at most one decimal point, at least one digit.
+	seenDigit := false
+	seenDot := false
+	for _, r := range mantissa {
+		switch {
+		case r >= '0' && r <= '9':
+			seenDigit = true
+		case r == '.':
+			if seenDot {
+				return false
+			}
+			seenDot = true
+		default:
+			return false
+		}
+	}
+	if !seenDigit {
+		return false
+	}
+
+	// Exponent: optional sign then at least one digit.
+	exp = strings.TrimPrefix(strings.TrimPrefix(exp, "+"), "-")
+	if exp == "" {
+		return false
+	}
+	for _, r := range exp {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func toNumber(value string) (*NumberValue, error) {
 	if len(value) == 0 {
 		return nil, nil
@@ -609,6 +657,13 @@ func toNumber(value string) (*NumberValue, error) {
 		normalized = strings.TrimPrefix(normalized, "0b")
 		base = 2
 		typ = NumberTypeBinary
+	case hasDecimalExponent(normalized):
+		// Scientific notation without a mantissa dot, e.g. "1e+20".
+		// strconv.ParseFloat accepts this even though dotCount == 0, so it
+		// must be classified as a float and not fall through to the octal or
+		// decimal-integer cases (which would reject it, mis-typing it as a
+		// plain string on decode).
+		typ = NumberTypeFloat
 	case strings.HasPrefix(normalized, "0") && len(normalized) > 1 && dotCount == 0:
 		base = 8
 		typ = NumberTypeOctet


### PR DESCRIPTION
## What

Fixes #916.

A `float64` written in scientific notation without a mantissa dot survives one decode but is turned into a **string** on the next roundtrip:

```go
var before map[string]any
yaml.Unmarshal([]byte("value: 100000000000000000000.\n"), &before) // before["value"] == float64(1e+20)
encoded, _ := yaml.Marshal(before)                                 // "value: 1e+20\n"
var after map[string]any
yaml.Unmarshal(encoded, &after)                                    // after["value"] == string("1e+20")  ❌
```

So `map[string]any` -> `Marshal` -> `Unmarshal` does not preserve the `float64`.

## Cause

`toNumber` (in `token`) only classified a value as `NumberTypeFloat` when it contained a decimal point:

```go
case dotCount == 1:
    typ = NumberTypeFloat
```

An exponent form like `1e20` / `1e+20` has `dotCount == 0`, so it fell through to the decimal-integer case, `strconv.ParseInt` failed, and the scalar was treated as a plain string — even though `strconv.ParseFloat` accepts it. `Marshal` emits `1e+20` (no dot), which then fails to re-parse as a float.

## Fix

Add `hasDecimalExponent` and classify base-10 exponent forms as floats. It runs **after** the `0x`/`0o`/`0b` prefixes are stripped, so a hex `e` is never mistaken for an exponent, and it requires digits on both sides of the `e`/`E` marker so `"e10"`, `"1e"`, `"1e+"`, `"1ee5"`, `"1e1.5"` remain non-numeric.

## Verification (real results, Go)

- `go test ./...` — all packages pass, no regressions.
- New `token` unit test `TestToNumberScientificNotation` covers the positive cases (`1e+20`, `1e20`, `1E+20`, `-1e+20`, `1E-5`, `0e0`, …) and the negatives (`e10`, `1e`, `1ee5`, `0x1e`, `1e1.5`, …).
- New end-to-end `TestRoundtripScientificNotationIssue916` reproduces the issue: it fails on `master` (decodes back to `string`) and passes with this change.

`gofmt`/`go vet` clean.
