### PR TITLE
fix: render colon on separate line for explicit '?' key

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1436,8 +1436,14 @@ func (n *MappingValueNode) String() string {
 
 func (n *MappingValueNode) toString() string {
 	space := strings.Repeat(" ", n.Key.GetToken().Position.Column-1)
+	// Key with explicit '?' indicator requires the colon and value on a separate line.
+	// See https://github.com/goccy/go-yaml/issues/833
+	colonIndent := ""
+	if _, ok := n.Key.(*MappingKeyNode); ok {
+		colonIndent = "\n" + space
+	}
 	if checkLineBreak(n.Key.GetToken()) {
-		space = fmt.Sprintf("%s%s", "\n", space)
+		space = "\n" + space
 	}
 	keyIndentLevel := n.Key.GetToken().Position.IndentLevel
 	valueIndentLevel := n.Value.GetToken().Position.IndentLevel
@@ -1446,9 +1452,9 @@ func (n *MappingValueNode) toString() string {
 		value := n.Value.String()
 		if value == "" {
 			// implicit null value.
-			return fmt.Sprintf("%s%s:", space, n.Key.String())
+			return fmt.Sprintf("%s%s%s:", space, n.Key.String(), colonIndent)
 		}
-		return fmt.Sprintf("%s%s: %s", space, n.Key.String(), value)
+		return fmt.Sprintf("%s%s%s: %s", space, n.Key.String(), colonIndent, value)
 	} else if keyIndentLevel < valueIndentLevel && !n.IsFlowStyle {
 		valueStr := n.Value.String()
 		// For flow-style values indented on the next line, we need to add the proper indentation
@@ -1461,44 +1467,47 @@ func (n *MappingValueNode) toString() string {
 		}
 		if keyComment != nil {
 			return fmt.Sprintf(
-				"%s%s: %s\n%s",
+				"%s%s%s: %s\n%s",
 				space,
 				n.Key.stringWithoutComment(),
+				colonIndent,
 				keyComment.String(),
 				valueStr,
 			)
 		}
-		return fmt.Sprintf("%s%s:\n%s", space, n.Key.String(), valueStr)
+		return fmt.Sprintf("%s%s%s:\n%s", space, n.Key.String(), colonIndent, valueStr)
 	} else if m, ok := n.Value.(*MappingNode); ok && (m.IsFlowStyle || len(m.Values) == 0) {
-		return fmt.Sprintf("%s%s: %s", space, n.Key.String(), n.Value.String())
+		return fmt.Sprintf("%s%s%s: %s", space, n.Key.String(), colonIndent, n.Value.String())
 	} else if s, ok := n.Value.(*SequenceNode); ok && (s.IsFlowStyle || len(s.Values) == 0) {
-		return fmt.Sprintf("%s%s: %s", space, n.Key.String(), n.Value.String())
+		return fmt.Sprintf("%s%s%s: %s", space, n.Key.String(), colonIndent, n.Value.String())
 	} else if _, ok := n.Value.(*AnchorNode); ok {
-		return fmt.Sprintf("%s%s: %s", space, n.Key.String(), n.Value.String())
+		return fmt.Sprintf("%s%s%s: %s", space, n.Key.String(), colonIndent, n.Value.String())
 	} else if _, ok := n.Value.(*AliasNode); ok {
-		return fmt.Sprintf("%s%s: %s", space, n.Key.String(), n.Value.String())
+		return fmt.Sprintf("%s%s%s: %s", space, n.Key.String(), colonIndent, n.Value.String())
 	} else if _, ok := n.Value.(*TagNode); ok {
-		return fmt.Sprintf("%s%s: %s", space, n.Key.String(), n.Value.String())
+		return fmt.Sprintf("%s%s%s: %s", space, n.Key.String(), colonIndent, n.Value.String())
 	}
 
 	if keyComment != nil {
 		return fmt.Sprintf(
-			"%s%s: %s\n%s",
+			"%s%s%s: %s\n%s",
 			space,
 			n.Key.stringWithoutComment(),
+			colonIndent,
 			keyComment.String(),
 			n.Value.String(),
 		)
 	}
 	if m, ok := n.Value.(*MappingNode); ok && m.Comment != nil {
 		return fmt.Sprintf(
-			"%s%s: %s",
+			"%s%s%s: %s",
 			space,
 			n.Key.String(),
+			colonIndent,
 			strings.TrimLeft(n.Value.String(), " "),
 		)
 	}
-	return fmt.Sprintf("%s%s:\n%s", space, n.Key.String(), n.Value.String())
+	return fmt.Sprintf("%s%s%s:\n%s", space, n.Key.String(), colonIndent, n.Value.String())
 }
 
 // MapRange implements MapNode protocol

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -769,6 +769,141 @@ a:
 d: e
 `,
 		},
+		{
+			`
+? |
+    multi
+    line
+    key
+: value
+`, `
+? |
+    multi
+    line
+    key
+: value
+`,
+		},
+		{
+			`
+? key
+: value
+`, `
+? key
+: value
+`,
+		},
+		{
+			`
+? key
+`, `
+? key
+:
+`,
+		},
+		{
+			`
+? hello
+  world
+: value
+`, `
+? hello world
+: value
+`,
+		},
+		{
+			`
+? key
+: - a
+  - b
+`, `
+? key
+:
+  - a
+  - b
+`,
+		},
+		{
+			`
+? key
+:
+  a: 1
+  b: 2
+`, `
+? key
+:
+  a: 1
+  b: 2
+`,
+		},
+		{
+			`
+- ? key
+  : value
+- other
+`, `
+- ? key
+  : value
+- other
+`,
+		},
+		{
+			`
+top:
+  mid:
+    ? key
+    : value
+`, `
+top:
+  mid:
+    ? key
+    : value
+`,
+		},
+		{
+			`
+? key
+: &a value
+`, `
+? key
+: &a value
+`,
+		},
+		{
+			`
+? key
+: [1, 2]
+`, `
+? key
+: [1, 2]
+`,
+		},
+		{
+			`
+? key
+: |
+  text
+`, `
+? key
+: |
+  text
+`,
+		},
+		{
+			`
+? key
+:
+  - a: 1
+    b: 2
+  - c: 3
+`, `
+? key
+:
+  - a: 1
+    b: 2
+  - c: 3
+`,
+		},
 	}
 
 	for _, test := range tests {
@@ -1654,6 +1789,29 @@ a: #commentB
   # commentG
   - e # commentG
 # commentH
+`,
+		},
+		{
+			name: "explicit key with comment and block map value",
+			yaml: `
+? key # comment
+:
+  a: 1
+  b: 2
+`,
+		},
+		{
+			name: "explicit key with comment and block seq value",
+			yaml: `
+? key # comment
+: - 1
+  - 2
+`,
+			expected: `
+? key # comment
+:
+  - 1
+  - 2
 `,
 		},
 	}


### PR DESCRIPTION
`MappingValueNode.toString()` placed the colon and value on the same line as the key, which changes semantics for keys using the explicit '?' indicator.

Added `colonIndent` separator so the colon goes on a new line at the key's indentation level.

Fixes #833