### PR TITLE
fix(ast): keep a scalar value on its own line after an inline key comment

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1448,6 +1448,21 @@ func (n *MappingValueNode) toString() string {
 			// implicit null value.
 			return fmt.Sprintf("%s%s:", space, n.Key.String())
 		}
+		if keyComment != nil && keyIndentLevel < valueIndentLevel {
+			// the comment ends the key's line, so the value keeps its own line.
+			// ----
+			// key: # comment
+			//   value
+			valueSpace := strings.Repeat(" ", n.Value.GetToken().Position.Column-1)
+			return fmt.Sprintf(
+				"%s%s: %s\n%s%s",
+				space,
+				n.Key.stringWithoutComment(),
+				keyComment.String(),
+				valueSpace,
+				value,
+			)
+		}
 		return fmt.Sprintf("%s%s: %s", space, n.Key.String(), value)
 	} else if keyIndentLevel < valueIndentLevel && !n.IsFlowStyle {
 		valueStr := n.Value.String()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1573,6 +1573,22 @@ elem1:
 `,
 		},
 		{
+			name: "scalar value on the line after an inline key comment",
+			yaml: `
+key: # comment
+  value
+`,
+		},
+		{
+			name: "nested scalar value on the line after an inline key comment",
+			yaml: `
+a:
+  b: # comment
+    c
+d: e
+`,
+		},
+		{
 			name: "flow map with inline value comment",
 			yaml: `
 a:


### PR DESCRIPTION
Fixes #825.

`MappingValueNode.toString()` takes the `ScalarNode` shortcut and formats `key: value` before it ever looks at the key's line comment. When the comment closes the key's line and the value sits on the next line, the comment gets inlined into the key and the `:` delimiter ends up on the wrong side of it:

```go
data := "key: # comment\n  value\n"
f, _ := parser.Parse(lexer.Tokenize(data), parser.ParseComments)
fmt.Println(f.String())
// key # comment: value
```

The output is no longer valid YAML — the comment swallows the mapping delimiter, so re-parsing it gives a single scalar key.

The AST itself is fine: the comment is correctly attached as the key's line comment in every case. Mapping and sequence values already print it properly via the `keyComment` branch further down, which is why only plain scalars on a following line were affected:

```
key: # comment      key: # comment      key: # comment
  value               n: 1                - a
-> broken           -> ok               -> ok
```

This takes the same route for scalars, indenting the value with its own token column so the result round-trips:

```
key: # comment
  value
```

I added the plain and the nested case to `TestComment`; both fail on `master` and pass here. `go test ./...` is green, and I checked that the new output is idempotent under a re-parse (including deeper indentation, quoted/integer/bool scalars, and `|`/`>` block scalars, which are `LiteralNode` and don't take the scalar path).
