### PR TITLE
fix(parser): accept an anchor with no value at the end of the stream

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1113,6 +1113,10 @@ merge:
 			},
 		},
 		{
+			source: "a: 1\nconfig: &config\n",
+			value:  map[string]any{"a": uint64(1), "config": nil},
+		},
+		{
 			source: `{a: &a c, *a : b}`,
 			value:  map[string]string{"a": "c", "c": "b"},
 		},

--- a/parser/context.go
+++ b/parser/context.go
@@ -120,7 +120,7 @@ func (c *context) next() bool {
 }
 
 func (c *context) insertNullToken(tk *Token) *Token {
-	nullToken := c.createImplicitNullToken(tk)
+	nullToken := createImplicitNullToken(tk)
 	c.insertToken(nullToken)
 	c.goNext()
 
@@ -128,7 +128,7 @@ func (c *context) insertNullToken(tk *Token) *Token {
 }
 
 func (c *context) addNullValueToken(tk *Token) *Token {
-	nullToken := c.createImplicitNullToken(tk)
+	nullToken := createImplicitNullToken(tk)
 	rawTk := nullToken.RawToken()
 
 	// add space for map or sequence value.
@@ -140,7 +140,7 @@ func (c *context) addNullValueToken(tk *Token) *Token {
 	return nullToken
 }
 
-func (c *context) createImplicitNullToken(base *Token) *Token {
+func createImplicitNullToken(base *Token) *Token {
 	pos := *(base.RawToken().Position)
 	pos.Column++
 	tk := token.New("null", " null", &pos)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -755,7 +755,7 @@ func (p *parser) parseMapValue(ctx *context, key ast.MapKeyNode, colonTk *Token)
 		// next
 		group := &TokenGroup{
 			Type:   TokenGroupAnchor,
-			Tokens: []*Token{tk, ctx.createImplicitNullToken(tk)},
+			Tokens: []*Token{tk, createImplicitNullToken(tk)},
 		}
 		anchor, err := p.parseAnchor(ctx.withGroup(group), group)
 		if err != nil {
@@ -792,7 +792,7 @@ func (p *parser) parseMapValue(ctx *context, key ast.MapKeyNode, colonTk *Token)
 		// next
 		group := &TokenGroup{
 			Type:   TokenGroupAnchor,
-			Tokens: []*Token{tk, ctx.createImplicitNullToken(tk)},
+			Tokens: []*Token{tk, createImplicitNullToken(tk)},
 		}
 		anchor, err := p.parseAnchor(ctx.withGroup(group), group)
 		if err != nil {
@@ -984,7 +984,7 @@ func (p *parser) parseTag(ctx *context) (*ast.TagNode, error) {
 
 func (p *parser) parseTagValue(ctx *context, tagRawTk *token.Token, tk *Token) (ast.Node, error) {
 	if tk == nil {
-		return newNullNode(ctx, ctx.createImplicitNullToken(&Token{Token: tagRawTk}))
+		return newNullNode(ctx, createImplicitNullToken(&Token{Token: tagRawTk}))
 	}
 	switch token.ReservedTagKeyword(tagRawTk.Value) {
 	case token.MappingTag, token.SetTag:
@@ -1154,7 +1154,7 @@ func (p *parser) parseSequenceValue(ctx *context, seqTk *Token) (ast.Node, error
 		// -
 		group := &TokenGroup{
 			Type:   TokenGroupAnchor,
-			Tokens: []*Token{tk, ctx.createImplicitNullToken(tk)},
+			Tokens: []*Token{tk, createImplicitNullToken(tk)},
 		}
 		anchor, err := p.parseAnchor(ctx.withGroup(group), group)
 		if err != nil {
@@ -1191,7 +1191,7 @@ func (p *parser) parseSequenceValue(ctx *context, seqTk *Token) (ast.Node, error
 		// next
 		group := &TokenGroup{
 			Type:   TokenGroupAnchor,
-			Tokens: []*Token{tk, ctx.createImplicitNullToken(tk)},
+			Tokens: []*Token{tk, createImplicitNullToken(tk)},
 		}
 		anchor, err := p.parseAnchor(ctx.withGroup(group), group)
 		if err != nil {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -769,6 +769,24 @@ a:
 d: e
 `,
 		},
+		{
+			`
+a: 1
+config: &config
+`,
+			`
+a: 1
+config: &config
+`,
+		},
+		{
+			`
+- &item
+`,
+			`
+- &item
+`,
+		},
 	}
 
 	for _, test := range tests {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -787,6 +787,28 @@ config: &config
 - &item
 `,
 		},
+		{
+			`
+- &anchor
+- b
+`,
+			`
+- &anchor
+- b
+`,
+		},
+		{
+			`
+a:
+  - &anchor
+b: c
+`,
+			`
+a:
+  - &anchor
+b: c
+`,
+		},
 	}
 
 	for _, test := range tests {

--- a/parser/token.go
+++ b/parser/token.go
@@ -308,14 +308,24 @@ func createAnchorAndAliasTokenGroups(tokens []*Token) ([]*Token, error) {
 			if i+1 >= len(tokens) {
 				return nil, errors.ErrSyntax("undefined anchor name", tk.RawToken())
 			}
-			if i+2 >= len(tokens) {
-				return nil, errors.ErrSyntax("undefined anchor value", tk.RawToken())
-			}
 			anchorName := &Token{
 				Group: &TokenGroup{
 					Type:   TokenGroupAnchorName,
 					Tokens: []*Token{tk, tokens[i+1]},
 				},
+			}
+			if i+2 >= len(tokens) {
+				// nothing follows the anchor name, so it anchors the implicit null node.
+				// ----
+				// key: &anchor<EOF>
+				ret = append(ret, &Token{
+					Group: &TokenGroup{
+						Type:   TokenGroupAnchor,
+						Tokens: []*Token{anchorName, createImplicitNullToken(tokens[i+1])},
+					},
+				})
+				i++
+				continue
 			}
 			valueTk := tokens[i+2]
 			if tk.Line() == valueTk.Line() && valueTk.Type() == token.SequenceEntryType {


### PR DESCRIPTION
Fixes #827.

Whether a value-less anchor is accepted depends only on whether something happens to follow it:

```go
parser.Parse(lexer.Tokenize("config: &config\n"), 0)
// [1:9] undefined anchor value
// >  1 | config: &config

parser.Parse(lexer.Tokenize("config: &config\na: 1\n"), 0) // ok
```

`createAnchorAndAliasTokenGroups` returns `undefined anchor value` as soon as the anchor name is the last token in the stream, so the parser never reaches the branches in `parseMapValue`/`parseSequenceValue` that already turn a value-less anchor into the implicit null node. That's why the same document parses fine the moment another key is appended.

The document is valid YAML either way — the anchor simply names the empty node — and `gopkg.in/yaml.v3` decodes every one of these to a nil value:

| input | before | after / yaml.v3 |
| --- | --- | --- |
| `config: &config` | error | `{config: nil}` |
| `a: 1`<br>`config: &config` | error | `{a: 1, config: nil}` |
| `- &item` | error | `[nil]` |
| `config: &config`<br>`a: 1` | ok | ok |

So this groups the trailing anchor with an implicit null token rather than bailing out. That also keeps it from tripping the second `undefined anchor value` check in `createAnchorWithScalarTagTokenGroups`, which fires on a bare `TokenGroupAnchorName` at the end of the stream.

`createImplicitNullToken` never used its receiver, so I made it a plain function so `token.go` can call it instead of duplicating the token construction.

Notes:
- No existing test asserted the `undefined anchor value` message; the two new cases in `TestParseComplicatedDocument` (sitting next to the existing dangling-anchor case) reproduce the exact errors from the issue on `master`.
- Still rejected, as before: a bare `&` with no name (`undefined anchor name`) and an alias to an unknown anchor.
- I checked that aliasing a trailing anchor resolves to null (`config: &config` / `use: *config`), and added the map case to the decoder table.
- `go test ./...` and `go vet ./...` are clean.
